### PR TITLE
refactor: Upgrade to .NET Standard 2.0/2.1, tests in .NET 7.0

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 7.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/.gitignore
+++ b/.gitignore
@@ -129,7 +129,7 @@ publish/
 # Publish Web Output
 *.[Pp]ublish.xml
 *.azurePubxml
-# TODO: Comment the next line if you want to checkin your web deploy settings 
+# TODO: Comment the next line if you want to checkin your web deploy settings
 # but database connection strings (with potential passwords) will be unencrypted
 *.pubxml
 *.publishproj
@@ -194,3 +194,6 @@ FakesAssemblies/
 
 # Visual Studio 6 workspace options file
 *.opt
+
+# Rider
+.idea

--- a/Monzo.Tests/Extensions/DateTimeExtensionsTests.cs
+++ b/Monzo.Tests/Extensions/DateTimeExtensionsTests.cs
@@ -2,15 +2,14 @@
 using NUnit.Framework;
 using Monzo.Extensions;
 
-namespace Monzo.Tests.Extensions
+namespace Monzo.Tests.Extensions;
+
+[TestFixture]
+public sealed class DateTimeExtensionsTests
 {
-    [TestFixture]
-    public sealed class DateTimeExtensionsTests
+    [Test]
+    public void ToRfc3339String()
     {
-        [Test]
-        public void ToRfc3339String()
-        {
-            Assert.AreEqual("2015-04-05T18:01:32Z", new DateTime(2015, 4, 5, 18, 1, 32, DateTimeKind.Utc).ToRfc3339String());
-        }
+        Assert.AreEqual("2015-04-05T18:01:32Z", new DateTime(2015, 4, 5, 18, 1, 32, DateTimeKind.Utc).ToRfc3339String());
     }
 }

--- a/Monzo.Tests/Fakes/FakeHttpClientFactory.cs
+++ b/Monzo.Tests/Fakes/FakeHttpClientFactory.cs
@@ -1,19 +1,18 @@
-﻿namespace Monzo.Tests.Fakes
+﻿namespace Monzo.Tests.Fakes;
+
+using System;
+using System.Net;
+using System.Net.Http;
+
+internal static class FakeHttpClientFactory
 {
-    using System;
-    using System.Net;
-    using System.Net.Http;
-
-    internal static class FakeHttpClientFactory
+    public static (HttpClient httpClient, FakeHttpMessageHandler fakeMessageHandler) Create(HttpStatusCode statusCode, string responseContent)
     {
-        public static (HttpClient httpClient, FakeHttpMessageHandler fakeMessageHandler) Create(HttpStatusCode statusCode, string responseContent)
-        {
-            var fakeMessageHandler = new FakeHttpMessageHandler(statusCode, responseContent);
+        var fakeMessageHandler = new FakeHttpMessageHandler(statusCode, responseContent);
 
-            return (new HttpClient(fakeMessageHandler)
-            {
-                BaseAddress = new Uri("https://localhost")
-            }, fakeMessageHandler);
-        }
+        return (new HttpClient(fakeMessageHandler)
+        {
+            BaseAddress = new Uri("https://localhost")
+        }, fakeMessageHandler);
     }
 }

--- a/Monzo.Tests/Fakes/FakeHttpMessageHandler.cs
+++ b/Monzo.Tests/Fakes/FakeHttpMessageHandler.cs
@@ -1,41 +1,39 @@
-﻿namespace Monzo.Tests.Fakes
+﻿namespace Monzo.Tests.Fakes;
+
+using System.Collections.Specialized;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Web;
+
+internal class FakeHttpMessageHandler : HttpMessageHandler
 {
-    using System.Collections.Generic;
-    using System.Collections.Specialized;
-    using System.Net;
-    using System.Net.Http;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using System.Web;
+    private readonly HttpStatusCode _statusCode;
+    private readonly string _responseContent;
 
-    internal class FakeHttpMessageHandler : HttpMessageHandler
+    public HttpRequestMessage Request;
+
+    public FakeHttpMessageHandler(HttpStatusCode statusCode, string responseContent)
     {
-        private readonly HttpStatusCode _statusCode;
-        private readonly string _responseContent;
+        _statusCode = statusCode;
+        _responseContent = responseContent;
+    }
 
-        public HttpRequestMessage Request;
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        Request = request;
 
-        public FakeHttpMessageHandler(HttpStatusCode statusCode, string responseContent)
+        return Task.FromResult(new HttpResponseMessage()
         {
-            _statusCode = statusCode;
-            _responseContent = responseContent;
-        }
+            StatusCode = _statusCode,
+            Content = new StringContent(_responseContent)
+        });
+    }
 
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-        {
-            Request = request;
-
-            return Task.FromResult(new HttpResponseMessage()
-            {
-                StatusCode = _statusCode,
-                Content = new StringContent(_responseContent)
-            });
-        }
-
-        public async Task<NameValueCollection> GetQueryStringAsync()
-        {
-            var content = await Request.Content.ReadAsStringAsync();
-            return HttpUtility.ParseQueryString(content);
-        }
+    public async Task<NameValueCollection> GetQueryStringAsync()
+    {
+        var content = await Request.Content!.ReadAsStringAsync();
+        return HttpUtility.ParseQueryString(content);
     }
 }

--- a/Monzo.Tests/Messages/MerchantJsonConverterTests.cs
+++ b/Monzo.Tests/Messages/MerchantJsonConverterTests.cs
@@ -2,45 +2,44 @@
 using Newtonsoft.Json;
 using NUnit.Framework;
 
-namespace Monzo.Tests.Messages
+namespace Monzo.Tests.Messages;
+
+[TestFixture]
+public sealed class MerchantJsonConverterTests
 {
-    [TestFixture]
-    public sealed class MerchantJsonConverterTests
+    [Test]
+    public void Null()
     {
-        [Test]
-        public void Null()
-        {
-            var message = JsonConvert.DeserializeObject<TestMessage>("{'merchant': null}");
-            Assert.IsNull(message.Merchant);
-        }
+        var message = JsonConvert.DeserializeObject<TestMessage>("{'merchant': null}");
+        Assert.IsNull(message.Merchant);
+    }
 
-        [Test]
-        public void Missing()
-        {
-            var message = JsonConvert.DeserializeObject<TestMessage>("{}");
-            Assert.IsNull(message.Merchant);
-        }
+    [Test]
+    public void Missing()
+    {
+        var message = JsonConvert.DeserializeObject<TestMessage>("{}");
+        Assert.IsNull(message.Merchant);
+    }
 
-        [Test]
-        public void String()
-        {
-            var message = JsonConvert.DeserializeObject<TestMessage>("{'merchant': '1234'}");
-            Assert.AreEqual("1234", message.Merchant.Id);
-        }
+    [Test]
+    public void String()
+    {
+        var message = JsonConvert.DeserializeObject<TestMessage>("{'merchant': '1234'}");
+        Assert.AreEqual("1234", message.Merchant.Id);
+    }
 
-        [Test]
-        public void Object()
-        {
-            var message = JsonConvert.DeserializeObject<TestMessage>("{'merchant': {'id':'1234', 'name':'testMerchant'}}");
-            Assert.AreEqual("1234", message.Merchant.Id);
-            Assert.AreEqual("testMerchant", message.Merchant.Name);
-        }
+    [Test]
+    public void Object()
+    {
+        var message = JsonConvert.DeserializeObject<TestMessage>("{'merchant': {'id':'1234', 'name':'testMerchant'}}");
+        Assert.AreEqual("1234", message.Merchant.Id);
+        Assert.AreEqual("testMerchant", message.Merchant.Name);
+    }
 
-        private sealed class TestMessage
-        {
-            [JsonProperty("merchant")]
-            [JsonConverter(typeof(MerchantJsonConverter))]
-            public Merchant Merchant { get; set; }
-        }
+    private sealed class TestMessage
+    {
+        [JsonProperty("merchant")]
+        [JsonConverter(typeof(MerchantJsonConverter))]
+        public Merchant Merchant { get; set; }
     }
 }

--- a/Monzo.Tests/Monzo.Tests.csproj
+++ b/Monzo.Tests/Monzo.Tests.csproj
@@ -1,16 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
-
+    <TargetFramework>net7.0</TargetFramework>
     <IsPackable>false</IsPackable>
+    <LangVersion>default</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="5.0.3" />
-    <PackageReference Include="NUnit" Version="3.13.1" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="7.0.3" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Monzo.Tests/Monzo.Tests.csproj
+++ b/Monzo.Tests/Monzo.Tests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="7.0.3" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
   </ItemGroup>
 

--- a/Monzo.Tests/MonzoAuthorizationClientTests/MonzoAuthorizationClientTests.cs
+++ b/Monzo.Tests/MonzoAuthorizationClientTests/MonzoAuthorizationClientTests.cs
@@ -1,29 +1,29 @@
-﻿namespace Monzo.Tests.MonzoAuthorizationClientTests
+﻿namespace Monzo.Tests.MonzoAuthorizationClientTests;
+
+using Fakes;
+using NUnit.Framework;
+using System.Net;
+using System.Threading.Tasks;
+
+[TestFixture]
+public sealed class MonzoAuthorizationClientTests
 {
-    using Monzo.Tests.Fakes;
-    using NUnit.Framework;
-    using System.Net;
-    using System.Threading.Tasks;
-
-    [TestFixture]
-    public sealed class MonzoAuthorizationClientTests
+    [Test]
+    public void GetLoginPageUrl()
     {
-        [Test]
-        public void GetLoginPageUrl()
+        using (var client = new MonzoAuthorizationClient("testClientId", "testClientSecret", "http://foo"))
         {
-            using (var client = new Monzo.MonzoAuthorizationClient("testClientId", "testClientSecret", "http://foo"))
-            {
-                var loginPageUrl = client.GetAuthorizeUrl("testState", "testRedirectUri");
+            var loginPageUrl = client.GetAuthorizeUrl("testState", "testRedirectUri");
 
-                Assert.AreEqual("https://auth.monzo.com/?response_type=code&client_id=testClientId&state=testState&redirect_uri=testRedirectUri", loginPageUrl);
-            }
+            Assert.AreEqual("https://auth.monzo.com/?response_type=code&client_id=testClientId&state=testState&redirect_uri=testRedirectUri", loginPageUrl);
         }
+    }
 
-        [Test]
-        public async Task ExchangeCodeForAccessTokenAsync()
-        {
-            var (httpClient, fakeMessageHandler) = FakeHttpClientFactory.Create(HttpStatusCode.OK,
-                @"{
+    [Test]
+    public async Task ExchangeCodeForAccessTokenAsync()
+    {
+        var (httpClient, fakeMessageHandler) = FakeHttpClientFactory.Create(HttpStatusCode.OK,
+            @"{
                     'access_token': 'testAccessToken',
                     'client_id': 'client_id',
                     'expires_in': 21600,
@@ -32,32 +32,32 @@
                     'user_id': 'testUserId'
                 }");
 
-            using (var client = new MonzoAuthorizationClient(httpClient, "testClientId", "testClientSecret"))
-            {
-                var accessToken = await client.GetAccessTokenAsync("testCode", "testRedirectUri");
+        using (var client = new MonzoAuthorizationClient(httpClient, "testClientId", "testClientSecret"))
+        {
+            var accessToken = await client.GetAccessTokenAsync("testCode", "testRedirectUri");
 
-                Assert.AreEqual("testAccessToken", accessToken.Value);
-                Assert.AreEqual("testRefreshToken", accessToken.RefreshToken);
-                Assert.AreEqual("testUserId", accessToken.UserId);
-                Assert.AreEqual(21600, accessToken.ExpiresIn);
-            }
-
-            Assert.AreEqual("/oauth2/token", fakeMessageHandler.Request.RequestUri.PathAndQuery);
-
-            var formCollection = await fakeMessageHandler.GetQueryStringAsync();
-
-            Assert.AreEqual("authorization_code", formCollection["grant_type"]);
-            Assert.AreEqual("testClientId", formCollection["client_id"]);
-            Assert.AreEqual("testClientSecret", formCollection["client_secret"]);
-            Assert.AreEqual("testRedirectUri", formCollection["redirect_uri"]);
-            Assert.AreEqual("testCode", formCollection["code"]);
+            Assert.AreEqual("testAccessToken", accessToken.Value);
+            Assert.AreEqual("testRefreshToken", accessToken.RefreshToken);
+            Assert.AreEqual("testUserId", accessToken.UserId);
+            Assert.AreEqual(21600, accessToken.ExpiresIn);
         }
 
-        [Test]
-        public async Task Authenticate()
-        {
-            var (httpClient, fakeMessageHandler) = FakeHttpClientFactory.Create(HttpStatusCode.OK,
-                @"{
+        Assert.AreEqual("/oauth2/token", fakeMessageHandler.Request.RequestUri!.PathAndQuery);
+
+        var formCollection = await fakeMessageHandler.GetQueryStringAsync();
+
+        Assert.AreEqual("authorization_code", formCollection["grant_type"]);
+        Assert.AreEqual("testClientId", formCollection["client_id"]);
+        Assert.AreEqual("testClientSecret", formCollection["client_secret"]);
+        Assert.AreEqual("testRedirectUri", formCollection["redirect_uri"]);
+        Assert.AreEqual("testCode", formCollection["code"]);
+    }
+
+    [Test]
+    public async Task Authenticate()
+    {
+        var (httpClient, fakeMessageHandler) = FakeHttpClientFactory.Create(HttpStatusCode.OK,
+            @"{
                     'access_token': 'testAccessToken',
                     'client_id': 'client_id',
                     'expires_in': 21600,
@@ -67,32 +67,32 @@
                 }");
 
 
-            using (var client = new MonzoAuthorizationClient(httpClient, "testClientId", "testClientSecret"))
-            {
-                var accessToken = await client.AuthenticateAsync("testUsername", "testPassword");
+        using (var client = new MonzoAuthorizationClient(httpClient, "testClientId", "testClientSecret"))
+        {
+            var accessToken = await client.AuthenticateAsync("testUsername", "testPassword");
 
-                Assert.AreEqual("testAccessToken", accessToken.Value);
-                Assert.AreEqual("testRefreshToken", accessToken.RefreshToken);
-                Assert.AreEqual("testUserId", accessToken.UserId);
-                Assert.AreEqual(21600, accessToken.ExpiresIn);
-            }
-
-            Assert.AreEqual("/oauth2/token", fakeMessageHandler.Request.RequestUri.PathAndQuery);
-
-            var formCollection = await fakeMessageHandler.GetQueryStringAsync();
-
-            Assert.AreEqual("password", formCollection["grant_type"]);
-            Assert.AreEqual("testClientId", formCollection["client_id"]);
-            Assert.AreEqual("testClientSecret", formCollection["client_secret"]);
-            Assert.AreEqual("testUsername", formCollection["username"]);
-            Assert.AreEqual("testPassword", formCollection["password"]);
+            Assert.AreEqual("testAccessToken", accessToken.Value);
+            Assert.AreEqual("testRefreshToken", accessToken.RefreshToken);
+            Assert.AreEqual("testUserId", accessToken.UserId);
+            Assert.AreEqual(21600, accessToken.ExpiresIn);
         }
 
-        [Test]
-        public async Task RefreshAccessToken()
-        {
-            var (httpClient, fakeMessageHandler) = FakeHttpClientFactory.Create(HttpStatusCode.OK,
-                @"{
+        Assert.AreEqual("/oauth2/token", fakeMessageHandler.Request.RequestUri!.PathAndQuery);
+
+        var formCollection = await fakeMessageHandler.GetQueryStringAsync();
+
+        Assert.AreEqual("password", formCollection["grant_type"]);
+        Assert.AreEqual("testClientId", formCollection["client_id"]);
+        Assert.AreEqual("testClientSecret", formCollection["client_secret"]);
+        Assert.AreEqual("testUsername", formCollection["username"]);
+        Assert.AreEqual("testPassword", formCollection["password"]);
+    }
+
+    [Test]
+    public async Task RefreshAccessToken()
+    {
+        var (httpClient, fakeMessageHandler) = FakeHttpClientFactory.Create(HttpStatusCode.OK,
+            @"{
                     'access_token': 'testAccessToken2',
                     'client_id': 'client_id',
                     'expires_in': 21600,
@@ -101,24 +101,23 @@
                     'user_id': 'testUserId'
                 }");
 
-            using (var client = new MonzoAuthorizationClient(httpClient, "testClientId", "testClientSecret"))
-            {
-                var accessToken = await client.RefreshAccessTokenAsync("testAccessToken1");
+        using (var client = new MonzoAuthorizationClient(httpClient, "testClientId", "testClientSecret"))
+        {
+            var accessToken = await client.RefreshAccessTokenAsync("testAccessToken1");
 
-                Assert.AreEqual("testAccessToken2", accessToken.Value);
-                Assert.AreEqual("testRefreshToken2", accessToken.RefreshToken);
-                Assert.AreEqual(21600, accessToken.ExpiresIn);
-            }
-
-
-            Assert.AreEqual("/oauth2/token", fakeMessageHandler.Request.RequestUri.PathAndQuery);
-
-            var formCollection = await fakeMessageHandler.GetQueryStringAsync();
-
-            Assert.AreEqual("refresh_token", formCollection["grant_type"]);
-            Assert.AreEqual("testClientId", formCollection["client_id"]);
-            Assert.AreEqual("testClientSecret", formCollection["client_secret"]);
-            Assert.AreEqual("testAccessToken1", formCollection["refresh_token"]);
+            Assert.AreEqual("testAccessToken2", accessToken.Value);
+            Assert.AreEqual("testRefreshToken2", accessToken.RefreshToken);
+            Assert.AreEqual(21600, accessToken.ExpiresIn);
         }
+
+
+        Assert.AreEqual("/oauth2/token", fakeMessageHandler.Request.RequestUri!.PathAndQuery);
+
+        var formCollection = await fakeMessageHandler.GetQueryStringAsync();
+
+        Assert.AreEqual("refresh_token", formCollection["grant_type"]);
+        Assert.AreEqual("testClientId", formCollection["client_id"]);
+        Assert.AreEqual("testClientSecret", formCollection["client_secret"]);
+        Assert.AreEqual("testAccessToken1", formCollection["refresh_token"]);
     }
 }

--- a/Monzo.Tests/MonzoClientTests/Accounts.cs
+++ b/Monzo.Tests/MonzoClientTests/Accounts.cs
@@ -1,19 +1,19 @@
-﻿namespace Monzo.Tests.MonzoClientTests
-{
-    using System;
-    using System.Net;
-    using System.Threading.Tasks;
-    using Monzo.Tests.Fakes;
-    using NUnit.Framework;
+﻿namespace Monzo.Tests.MonzoClientTests;
 
-    [TestFixture]
-    public sealed class Accounts
+using System;
+using System.Net;
+using System.Threading.Tasks;
+using Fakes;
+using NUnit.Framework;
+
+[TestFixture]
+public sealed class Accounts
+{
+    [Test]
+    public async Task CanGetAccounts()
     {
-        [Test]
-        public async Task CanGetAccounts()
-        {
-            var (httpClient, fakeMessageHandler) = FakeHttpClientFactory.Create(HttpStatusCode.OK,
-                @"{
+        var (httpClient, fakeMessageHandler) = FakeHttpClientFactory.Create(HttpStatusCode.OK,
+            @"{
                     'accounts': [
                         {
                             'id': 'acc_00009237aqC8c5umZmrRdh',
@@ -75,67 +75,74 @@
                     ]
                 }");
 
-            using (var client = new MonzoClient(httpClient, "testAccessToken"))
-            {
-                var accounts = await client.GetAccountsAsync();
+        using (var client = new MonzoClient(httpClient, "testAccessToken"))
+        {
+            var accounts = await client.GetAccountsAsync();
 
-                Assert.AreEqual(3, accounts.Count);
-                var singleAccount = accounts[0];
-                #region Single Account
-                Assert.AreEqual("acc_00009237aqC8c5umZmrRdh", singleAccount.Id);
-                Assert.AreEqual("Peter Pan's Account", singleAccount.Description);
-                Assert.AreEqual(AccountType.uk_retail, singleAccount.Type);
-                Assert.AreEqual("040004", singleAccount.SortCode);
-                Assert.AreEqual("12345678", singleAccount.AccountNumber);
-                Assert.AreEqual(false, singleAccount.Closed);
-                Assert.AreEqual(1, singleAccount.Owners.Length);
+            Assert.AreEqual(3, accounts.Count);
+            var singleAccount = accounts[0];
 
-                Assert.AreEqual("user_00009awdawdawdawdg", singleAccount.Owners[0].Id);
-                Assert.AreEqual("Peter Pan", singleAccount.Owners[0].PreferredName);
-                Assert.AreEqual("Peter", singleAccount.Owners[0].PreferredFirstName);
+            #region Single Account
 
-                Assert.AreEqual(new DateTime(2015, 11, 13, 12, 17, 42, DateTimeKind.Utc), singleAccount.Created);
-                #endregion
+            Assert.AreEqual("acc_00009237aqC8c5umZmrRdh", singleAccount.Id);
+            Assert.AreEqual("Peter Pan's Account", singleAccount.Description);
+            Assert.AreEqual(AccountType.uk_retail, singleAccount.Type);
+            Assert.AreEqual("040004", singleAccount.SortCode);
+            Assert.AreEqual("12345678", singleAccount.AccountNumber);
+            Assert.AreEqual(false, singleAccount.Closed);
+            Assert.AreEqual(1, singleAccount.Owners.Length);
 
-                var jointAccount = accounts[1];
-                #region Joint Account
-                Assert.AreEqual("acc_00009238aqC8c5umZmrRdh", jointAccount.Id);
-                Assert.AreEqual("Joint account between user_00009awdawdawdawdr and user_00009awdawdawdawdg", jointAccount.Description);
-                Assert.AreEqual(AccountType.uk_retail_joint, jointAccount.Type);
-                Assert.AreEqual("040004", jointAccount.SortCode);
-                Assert.AreEqual("567891234", jointAccount.AccountNumber);
-                Assert.AreEqual(true, jointAccount.Closed);
-                Assert.AreEqual(2, jointAccount.Owners.Length);
-                Assert.AreEqual("user_00009awdawdawdawdr", jointAccount.Owners[0].Id);
-                Assert.AreEqual("Captain Hook", jointAccount.Owners[0].PreferredName);
-                Assert.AreEqual("Hook", jointAccount.Owners[0].PreferredFirstName);
-                Assert.AreEqual("user_00009awdawdawdawdg", jointAccount.Owners[1].Id);
-                Assert.AreEqual("Peter Pan", jointAccount.Owners[1].PreferredName);
-                Assert.AreEqual("Peter", jointAccount.Owners[1].PreferredFirstName);
+            Assert.AreEqual("user_00009awdawdawdawdg", singleAccount.Owners[0].Id);
+            Assert.AreEqual("Peter Pan", singleAccount.Owners[0].PreferredName);
+            Assert.AreEqual("Peter", singleAccount.Owners[0].PreferredFirstName);
 
-                Assert.AreEqual(new DateTime(2019, 10, 27, 19, 50, 42, DateTimeKind.Utc), jointAccount.Created);
-                #endregion
+            Assert.AreEqual(new DateTime(2015, 11, 13, 12, 17, 42, DateTimeKind.Utc), singleAccount.Created);
 
-                var loan = accounts[2];
+            #endregion
 
-                #region Loan
-                Assert.AreEqual("acc_00009abcdefghijklmnopq", loan.Id);
-                Assert.AreEqual(false, loan.Closed);
-                Assert.AreEqual("loan_00009abcdefghijklmnopq", loan.Description);
-                Assert.AreEqual(AccountType.uk_loan, loan.Type);
-                Assert.AreEqual("GBP", loan.Currency);
-                Assert.AreEqual("GB", loan.CountryCode);
-                Assert.AreEqual("user_00009awdawdawdawdg", loan.Owners[0].Id);
-                Assert.AreEqual("Peter Pan", loan.Owners[0].PreferredName);
-                Assert.AreEqual("Peter", loan.Owners[0].PreferredFirstName);
+            var jointAccount = accounts[1];
 
-                Assert.AreEqual(new DateTime(2019, 10, 27, 19, 50, 42, DateTimeKind.Utc), loan.Created);
-                #endregion
-            }
+            #region Joint Account
 
-            Assert.AreEqual("/accounts", fakeMessageHandler.Request.RequestUri.PathAndQuery);
+            Assert.AreEqual("acc_00009238aqC8c5umZmrRdh", jointAccount.Id);
+            Assert.AreEqual("Joint account between user_00009awdawdawdawdr and user_00009awdawdawdawdg", jointAccount.Description);
+            Assert.AreEqual(AccountType.uk_retail_joint, jointAccount.Type);
+            Assert.AreEqual("040004", jointAccount.SortCode);
+            Assert.AreEqual("567891234", jointAccount.AccountNumber);
+            Assert.AreEqual(true, jointAccount.Closed);
+            Assert.AreEqual(2, jointAccount.Owners.Length);
+            Assert.AreEqual("user_00009awdawdawdawdr", jointAccount.Owners[0].Id);
+            Assert.AreEqual("Captain Hook", jointAccount.Owners[0].PreferredName);
+            Assert.AreEqual("Hook", jointAccount.Owners[0].PreferredFirstName);
+            Assert.AreEqual("user_00009awdawdawdawdg", jointAccount.Owners[1].Id);
+            Assert.AreEqual("Peter Pan", jointAccount.Owners[1].PreferredName);
+            Assert.AreEqual("Peter", jointAccount.Owners[1].PreferredFirstName);
 
-            Assert.AreEqual("Bearer testAccessToken", fakeMessageHandler.Request.Headers.Authorization.ToString());
+            Assert.AreEqual(new DateTime(2019, 10, 27, 19, 50, 42, DateTimeKind.Utc), jointAccount.Created);
+
+            #endregion
+
+            var loan = accounts[2];
+
+            #region Loan
+
+            Assert.AreEqual("acc_00009abcdefghijklmnopq", loan.Id);
+            Assert.AreEqual(false, loan.Closed);
+            Assert.AreEqual("loan_00009abcdefghijklmnopq", loan.Description);
+            Assert.AreEqual(AccountType.uk_loan, loan.Type);
+            Assert.AreEqual("GBP", loan.Currency);
+            Assert.AreEqual("GB", loan.CountryCode);
+            Assert.AreEqual("user_00009awdawdawdawdg", loan.Owners[0].Id);
+            Assert.AreEqual("Peter Pan", loan.Owners[0].PreferredName);
+            Assert.AreEqual("Peter", loan.Owners[0].PreferredFirstName);
+
+            Assert.AreEqual(new DateTime(2019, 10, 27, 19, 50, 42, DateTimeKind.Utc), loan.Created);
+
+            #endregion
         }
+
+        Assert.AreEqual("/accounts", fakeMessageHandler.Request.RequestUri!.PathAndQuery);
+
+        Assert.AreEqual("Bearer testAccessToken", fakeMessageHandler.Request.Headers.Authorization!.ToString());
     }
 }

--- a/Monzo.Tests/MonzoClientTests/Attachements.cs
+++ b/Monzo.Tests/MonzoClientTests/Attachements.cs
@@ -1,19 +1,19 @@
-﻿namespace Monzo.Tests.MonzoClientTests
-{
-    using System;
-    using System.Net;
-    using System.Threading.Tasks;
-    using Monzo.Tests.Fakes;
-    using NUnit.Framework;
+﻿namespace Monzo.Tests.MonzoClientTests;
 
-    [TestFixture]
-    public sealed class Attachements
+using System;
+using System.Net;
+using System.Threading.Tasks;
+using Fakes;
+using NUnit.Framework;
+
+[TestFixture]
+public sealed class Attachements
+{
+    [Test]
+    public async Task CanCreateAttachment()
     {
-        [Test]
-        public async Task CanCreateAttachment()
-        {
-            var (httpClient, fakeMessageHandler) = FakeHttpClientFactory.Create(HttpStatusCode.OK,
-                @"{
+        var (httpClient, fakeMessageHandler) = FakeHttpClientFactory.Create(HttpStatusCode.OK,
+            @"{
                     'attachment': {
                         'id': 'attach_00009238aOAIvVqfb9LrZh',
                         'user_id': 'user_00009238aMBIIrS5Rdncq9',
@@ -24,48 +24,47 @@
                     }
                 }");
 
-                using (var client = new MonzoClient(httpClient, "testAccessToken"))
-                {
-                    var attachment = await client.CreateAttachmentAsync("tx_00008zIcpb1TB4yeIFXMzx", "https://s3-eu-west-1.amazonaws.com/mondo-image-uploads/user_00009237hliZellUicKuG1/LcCu4ogv1xW28OCcvOTL-foo.png", "image/png");
-
-                    Assert.AreEqual("attach_00009238aOAIvVqfb9LrZh", attachment.Id);
-                    Assert.AreEqual("user_00009238aMBIIrS5Rdncq9", attachment.UserId);
-                    Assert.AreEqual("tx_00008zIcpb1TB4yeIFXMzx", attachment.ExternalId);
-                    Assert.AreEqual("https://s3-eu-west-1.amazonaws.com/mondo-image-uploads/user_00009237hliZellUicKuG1/LcCu4ogv1xW28OCcvOTL-foo.png", attachment.FileUrl);
-                    Assert.AreEqual("image/png", attachment.FileType);
-                    Assert.AreEqual(new DateTime(2015, 11, 12, 18, 37, 2, DateTimeKind.Utc), attachment.Created);
-                }
-
-                Assert.AreEqual("/attachment/register", fakeMessageHandler.Request.RequestUri.PathAndQuery);
-                Assert.AreEqual("POST", fakeMessageHandler.Request.Method.ToString());
-
-                Assert.AreEqual("Bearer testAccessToken", fakeMessageHandler.Request.Headers.Authorization.ToString());
-
-                var formCollection = await fakeMessageHandler.GetQueryStringAsync();
-
-                Assert.AreEqual("tx_00008zIcpb1TB4yeIFXMzx", formCollection["external_id"]);
-                Assert.AreEqual("image/png", formCollection["file_type"]);
-                Assert.AreEqual("https://s3-eu-west-1.amazonaws.com/mondo-image-uploads/user_00009237hliZellUicKuG1/LcCu4ogv1xW28OCcvOTL-foo.png", formCollection["file_url"]);
-        }
-
-        [Test]
-        public async Task CanDeleteAttachment()
+        using (var client = new MonzoClient(httpClient, "testAccessToken"))
         {
-            var (httpClient, fakeMessageHandler) = FakeHttpClientFactory.Create(HttpStatusCode.OK, "{}");
+            var attachment = await client.CreateAttachmentAsync("tx_00008zIcpb1TB4yeIFXMzx", "https://s3-eu-west-1.amazonaws.com/mondo-image-uploads/user_00009237hliZellUicKuG1/LcCu4ogv1xW28OCcvOTL-foo.png", "image/png");
 
-            using (var client = new MonzoClient(httpClient, "testAccessToken"))
-            {
-                await client.DeleteAttachmentAsync("attach_00009238aOAIvVqfb9LrZh");
-            }
-
-            Assert.AreEqual("/attachment/deregister", fakeMessageHandler.Request.RequestUri.PathAndQuery);
-            Assert.AreEqual("POST", fakeMessageHandler.Request.Method.ToString());
-
-            Assert.AreEqual("Bearer testAccessToken", fakeMessageHandler.Request.Headers.Authorization.ToString());
-
-            var formCollection = await fakeMessageHandler.GetQueryStringAsync();
-
-            Assert.AreEqual("attach_00009238aOAIvVqfb9LrZh", formCollection["id"]);
+            Assert.AreEqual("attach_00009238aOAIvVqfb9LrZh", attachment.Id);
+            Assert.AreEqual("user_00009238aMBIIrS5Rdncq9", attachment.UserId);
+            Assert.AreEqual("tx_00008zIcpb1TB4yeIFXMzx", attachment.ExternalId);
+            Assert.AreEqual("https://s3-eu-west-1.amazonaws.com/mondo-image-uploads/user_00009237hliZellUicKuG1/LcCu4ogv1xW28OCcvOTL-foo.png", attachment.FileUrl);
+            Assert.AreEqual("image/png", attachment.FileType);
+            Assert.AreEqual(new DateTime(2015, 11, 12, 18, 37, 2, DateTimeKind.Utc), attachment.Created);
         }
+
+        Assert.AreEqual("/attachment/register", fakeMessageHandler.Request.RequestUri!.PathAndQuery);
+        Assert.AreEqual("POST", fakeMessageHandler.Request.Method.ToString());
+
+        Assert.AreEqual("Bearer testAccessToken", fakeMessageHandler.Request.Headers.Authorization!.ToString());
+
+        var formCollection = await fakeMessageHandler.GetQueryStringAsync();
+
+        Assert.AreEqual("tx_00008zIcpb1TB4yeIFXMzx", formCollection["external_id"]);
+        Assert.AreEqual("image/png", formCollection["file_type"]);
+        Assert.AreEqual("https://s3-eu-west-1.amazonaws.com/mondo-image-uploads/user_00009237hliZellUicKuG1/LcCu4ogv1xW28OCcvOTL-foo.png", formCollection["file_url"]);
+    }
+
+    [Test]
+    public async Task CanDeleteAttachment()
+    {
+        var (httpClient, fakeMessageHandler) = FakeHttpClientFactory.Create(HttpStatusCode.OK, "{}");
+
+        using (var client = new MonzoClient(httpClient, "testAccessToken"))
+        {
+            await client.DeleteAttachmentAsync("attach_00009238aOAIvVqfb9LrZh");
+        }
+
+        Assert.AreEqual("/attachment/deregister", fakeMessageHandler.Request.RequestUri!.PathAndQuery);
+        Assert.AreEqual("POST", fakeMessageHandler.Request.Method.ToString());
+
+        Assert.AreEqual("Bearer testAccessToken", fakeMessageHandler.Request.Headers.Authorization!.ToString());
+
+        var formCollection = await fakeMessageHandler.GetQueryStringAsync();
+
+        Assert.AreEqual("attach_00009238aOAIvVqfb9LrZh", formCollection["id"]);
     }
 }

--- a/Monzo.Tests/MonzoClientTests/Balance.cs
+++ b/Monzo.Tests/MonzoClientTests/Balance.cs
@@ -1,35 +1,34 @@
-﻿namespace Monzo.Tests.MonzoClientTests
-{
-    using Monzo.Tests.Fakes;
-    using NUnit.Framework;
-    using System.Net;
-    using System.Threading.Tasks;
+﻿namespace Monzo.Tests.MonzoClientTests;
 
-    [TestFixture]
-    public sealed class Balance
+using Fakes;
+using NUnit.Framework;
+using System.Net;
+using System.Threading.Tasks;
+
+[TestFixture]
+public sealed class Balance
+{
+    [Test]
+    public async Task CanGetBalance()
     {
-        [Test]
-        public async Task CanGetBalance()
-        {
-            var (httpClient, fakeMessageHandler) = FakeHttpClientFactory.Create(HttpStatusCode.OK,
-                @"{
+        var (httpClient, fakeMessageHandler) = FakeHttpClientFactory.Create(HttpStatusCode.OK,
+            @"{
                     'balance': 5000,
                     'currency': 'GBP',
                     'spend_today': -100
                 }");
- 
-            using (var client = new MonzoClient(httpClient, "testAccessToken"))
-            {
-                var balance = await client.GetBalanceAsync("1");
 
-                Assert.AreEqual(5000, balance.Value);
-                Assert.AreEqual("GBP", balance.Currency);
-                Assert.AreEqual(-100, balance.SpendToday);
-            }
+        using (var client = new MonzoClient(httpClient, "testAccessToken"))
+        {
+            var balance = await client.GetBalanceAsync("1");
 
-            Assert.AreEqual("/balance?account_id=1", fakeMessageHandler.Request.RequestUri.PathAndQuery);
-
-            Assert.AreEqual("Bearer testAccessToken", fakeMessageHandler.Request.Headers.Authorization.ToString());
+            Assert.AreEqual(5000, balance.Value);
+            Assert.AreEqual("GBP", balance.Currency);
+            Assert.AreEqual(-100, balance.SpendToday);
         }
+
+        Assert.AreEqual("/balance?account_id=1", fakeMessageHandler.Request.RequestUri!.PathAndQuery);
+
+        Assert.AreEqual("Bearer testAccessToken", fakeMessageHandler.Request.Headers.Authorization!.ToString());
     }
 }

--- a/Monzo.Tests/MonzoClientTests/Feed.cs
+++ b/Monzo.Tests/MonzoClientTests/Feed.cs
@@ -1,33 +1,32 @@
-﻿namespace Monzo.Tests.MonzoClientTests
+﻿namespace Monzo.Tests.MonzoClientTests;
+
+using System.Collections.Generic;
+using System.Net;
+using System.Threading.Tasks;
+using Fakes;
+using NUnit.Framework;
+
+[TestFixture]
+public sealed class Feed
 {
-    using System.Collections.Generic;
-    using System.Net;
-    using System.Threading.Tasks;
-    using Monzo.Tests.Fakes;
-    using NUnit.Framework;
-
-    [TestFixture]
-    public sealed class Feed
+    [Test]
+    public async Task CanCreateFeedItem()
     {
-        [Test]
-        public async Task CanCreateFeedItem()
+        var (httpClient, fakeMessageHandler) = FakeHttpClientFactory.Create(HttpStatusCode.OK, "{}");
+
+        using (var client = new MonzoClient(httpClient, "testAccessToken"))
         {
-            var (httpClient, fakeMessageHandler) = FakeHttpClientFactory.Create(HttpStatusCode.OK, "{}");
-
-            using (var client = new MonzoClient(httpClient, "testAccessToken"))
-            {
-                await client.CreateFeedItemAsync("1", "basic", new Dictionary<string, string> { { "title", "My custom item" } }, "https://www.example.com/a_page_to_open_on_tap.html");
-            }
-
-                                Assert.AreEqual("Bearer testAccessToken", fakeMessageHandler.Request.Headers.Authorization.ToString());
-            Assert.AreEqual("POST", fakeMessageHandler.Request.Method.ToString());
-            Assert.AreEqual("/feed", fakeMessageHandler.Request.RequestUri.PathAndQuery);
-
-            var formCollection = await fakeMessageHandler.GetQueryStringAsync();
-            Assert.AreEqual("1", formCollection["account_id"]);
-            Assert.AreEqual("basic", formCollection["type"]);
-            Assert.AreEqual("https://www.example.com/a_page_to_open_on_tap.html", formCollection["url"]);
-            Assert.AreEqual("My custom item", formCollection["params[title]"]);
+            await client.CreateFeedItemAsync("1", "basic", new Dictionary<string, string> { { "title", "My custom item" } }, "https://www.example.com/a_page_to_open_on_tap.html");
         }
+
+        Assert.AreEqual("Bearer testAccessToken", fakeMessageHandler.Request.Headers.Authorization!.ToString());
+        Assert.AreEqual("POST", fakeMessageHandler.Request.Method.ToString());
+        Assert.AreEqual("/feed", fakeMessageHandler.Request.RequestUri!.PathAndQuery);
+
+        var formCollection = await fakeMessageHandler.GetQueryStringAsync();
+        Assert.AreEqual("1", formCollection["account_id"]);
+        Assert.AreEqual("basic", formCollection["type"]);
+        Assert.AreEqual("https://www.example.com/a_page_to_open_on_tap.html", formCollection["url"]);
+        Assert.AreEqual("My custom item", formCollection["params[title]"]);
     }
 }

--- a/Monzo.Tests/MonzoClientTests/Pots.cs
+++ b/Monzo.Tests/MonzoClientTests/Pots.cs
@@ -1,21 +1,21 @@
-﻿namespace Monzo.Tests.MonzoClientTests
+﻿namespace Monzo.Tests.MonzoClientTests;
+
+using System;
+using System.Net;
+using System.Threading.Tasks;
+using Fakes;
+using NUnit.Framework;
+
+[TestFixture]
+public sealed class Pots
 {
-    using System;
-    using System.Net;
-    using System.Threading.Tasks;
-    using Monzo.Tests.Fakes;
-    using NUnit.Framework;
-
-    [TestFixture]
-    public sealed class Pots
+    [Test]
+    public async Task CanGetPots()
     {
-        [Test]
-        public async Task CanGetPots()
-        {
-            var currentAccountId = "this_is_a_current_account";
+        var currentAccountId = "this_is_a_current_account";
 
-            var (httpClient, fakeMessageHandler) = FakeHttpClientFactory.Create(HttpStatusCode.OK,
-                @"{
+        var (httpClient, fakeMessageHandler) = FakeHttpClientFactory.Create(HttpStatusCode.OK,
+            @"{
                     'pots': [
                         {
                             'id': 'pot_0000123456789',
@@ -39,36 +39,36 @@
                 }");
 
 
-            using (var client = new MonzoClient(httpClient, "testAccessToken"))
-            {
-                var pots = await client.GetPotsAsync(currentAccountId);
+        using (var client = new MonzoClient(httpClient, "testAccessToken"))
+        {
+            var pots = await client.GetPotsAsync(currentAccountId);
 
-                Assert.AreEqual(1, pots.Count);
+            Assert.AreEqual(1, pots.Count);
 
-                var pot = pots[0];
-                Assert.AreEqual("pot_0000123456789", pot.Id);
-                Assert.AreEqual("Rainy Day", pot.Name);
-                Assert.AreEqual("beach_ball", pot.Style);
-                Assert.AreEqual(500, pot.Balance);
-                Assert.AreEqual("GBP", pot.Currency);
-                Assert.AreEqual("this_is_a_current_account", pot.CurrentAccountId);
-                Assert.AreEqual(new DateTime(2017, 12, 1, 23, 00, 26, 256, DateTimeKind.Utc), pot.Created);
-                Assert.AreEqual(new DateTime(2018, 1, 22, 8, 12, 49, 497, DateTimeKind.Utc), pot.Updated);
-                Assert.AreEqual(false, pot.RoundUp);
-                Assert.AreEqual(false, pot.Locked);
-                Assert.AreEqual(false, pot.Deleted);
-            }
-
-            Assert.AreEqual($"/pots?current_account_id={currentAccountId}", fakeMessageHandler.Request.RequestUri.PathAndQuery);
-
-            Assert.AreEqual("Bearer testAccessToken", fakeMessageHandler.Request.Headers.Authorization.ToString());
+            var pot = pots[0];
+            Assert.AreEqual("pot_0000123456789", pot.Id);
+            Assert.AreEqual("Rainy Day", pot.Name);
+            Assert.AreEqual("beach_ball", pot.Style);
+            Assert.AreEqual(500, pot.Balance);
+            Assert.AreEqual("GBP", pot.Currency);
+            Assert.AreEqual("this_is_a_current_account", pot.CurrentAccountId);
+            Assert.AreEqual(new DateTime(2017, 12, 1, 23, 00, 26, 256, DateTimeKind.Utc), pot.Created);
+            Assert.AreEqual(new DateTime(2018, 1, 22, 8, 12, 49, 497, DateTimeKind.Utc), pot.Updated);
+            Assert.AreEqual(false, pot.RoundUp);
+            Assert.AreEqual(false, pot.Locked);
+            Assert.AreEqual(false, pot.Deleted);
         }
 
-        [Test]
-        public async Task CanDepositIntoPot()
-        {
-            var (httpClient, fakeMessageHandler) = FakeHttpClientFactory.Create(HttpStatusCode.OK,
-                @"{
+        Assert.AreEqual($"/pots?current_account_id={currentAccountId}", fakeMessageHandler.Request.RequestUri!.PathAndQuery);
+
+        Assert.AreEqual("Bearer testAccessToken", fakeMessageHandler.Request.Headers.Authorization!.ToString());
+    }
+
+    [Test]
+    public async Task CanDepositIntoPot()
+    {
+        var (httpClient, fakeMessageHandler) = FakeHttpClientFactory.Create(HttpStatusCode.OK,
+            @"{
                     'id': 'pot_00009exampleP0tOxWb',
                     'name': 'Wedding Fund',
                     'style': 'beach_ball',
@@ -80,38 +80,38 @@
                     'deleted': false
                 }");
 
-            using (var client = new MonzoClient(httpClient, "testAccessToken"))
-            {
-                var updatedPot = await client.DepositIntoPotAsync("pot_00009exampleP0tOxWb", "test_account_123", 72932, "a_unique_id");
-
-                Assert.NotNull(updatedPot);
-
-                Assert.AreEqual("pot_00009exampleP0tOxWb", updatedPot.Id);
-                Assert.AreEqual("Wedding Fund", updatedPot.Name);
-                Assert.AreEqual("beach_ball", updatedPot.Style);
-                Assert.AreEqual(550100, updatedPot.Balance);
-                Assert.AreEqual("GBP", updatedPot.Currency);
-                Assert.AreEqual("test_account_123", updatedPot.CurrentAccountId);
-                Assert.AreEqual(new DateTime(2017, 11, 9, 12, 30, 53, 695, DateTimeKind.Utc), updatedPot.Created);
-                Assert.AreEqual(new DateTime(2018, 2, 26, 7, 12, 4, 925, DateTimeKind.Utc), updatedPot.Updated);
-                Assert.AreEqual(false, updatedPot.Deleted);
-            }
-            Assert.AreEqual("Bearer testAccessToken", fakeMessageHandler.Request.Headers.Authorization.ToString());
-            Assert.AreEqual("PUT", fakeMessageHandler.Request.Method.ToString());
-            Assert.AreEqual("/pots/pot_00009exampleP0tOxWb/deposit", fakeMessageHandler.Request.RequestUri.PathAndQuery);
-
-            var formCollection = await fakeMessageHandler.GetQueryStringAsync();
-
-            Assert.AreEqual("test_account_123", formCollection["source_account_id"]);
-            Assert.AreEqual("72932", formCollection["amount"]);
-            Assert.AreEqual("a_unique_id", formCollection["dedupe_id"]);
-        }
-
-        [Test]
-        public async Task CanWithdrawFromPot()
+        using (var client = new MonzoClient(httpClient, "testAccessToken"))
         {
-            var (httpClient, fakeMessageHandler) = FakeHttpClientFactory.Create(HttpStatusCode.OK,
-                @"{
+            var updatedPot = await client.DepositIntoPotAsync("pot_00009exampleP0tOxWb", "test_account_123", 72932, "a_unique_id");
+
+            Assert.NotNull(updatedPot);
+
+            Assert.AreEqual("pot_00009exampleP0tOxWb", updatedPot.Id);
+            Assert.AreEqual("Wedding Fund", updatedPot.Name);
+            Assert.AreEqual("beach_ball", updatedPot.Style);
+            Assert.AreEqual(550100, updatedPot.Balance);
+            Assert.AreEqual("GBP", updatedPot.Currency);
+            Assert.AreEqual("test_account_123", updatedPot.CurrentAccountId);
+            Assert.AreEqual(new DateTime(2017, 11, 9, 12, 30, 53, 695, DateTimeKind.Utc), updatedPot.Created);
+            Assert.AreEqual(new DateTime(2018, 2, 26, 7, 12, 4, 925, DateTimeKind.Utc), updatedPot.Updated);
+            Assert.AreEqual(false, updatedPot.Deleted);
+        }
+        Assert.AreEqual("Bearer testAccessToken", fakeMessageHandler.Request.Headers.Authorization!.ToString());
+        Assert.AreEqual("PUT", fakeMessageHandler.Request.Method.ToString());
+        Assert.AreEqual("/pots/pot_00009exampleP0tOxWb/deposit", fakeMessageHandler.Request.RequestUri!.PathAndQuery);
+
+        var formCollection = await fakeMessageHandler.GetQueryStringAsync();
+
+        Assert.AreEqual("test_account_123", formCollection["source_account_id"]);
+        Assert.AreEqual("72932", formCollection["amount"]);
+        Assert.AreEqual("a_unique_id", formCollection["dedupe_id"]);
+    }
+
+    [Test]
+    public async Task CanWithdrawFromPot()
+    {
+        var (httpClient, fakeMessageHandler) = FakeHttpClientFactory.Create(HttpStatusCode.OK,
+            @"{
                     'id': 'pot_00009exampleP0tOxWb',
                     'name': 'Flying Lessons',
                     'style': 'blue',
@@ -123,32 +123,31 @@
                     'deleted': false
                 }");
 
-            using (var client = new MonzoClient(httpClient, "testAccessToken"))
-            {
-                var updatedPot = await client.WithdrawFromPotAsync("pot_00009exampleP0tOxWb", "test_account_123", 500, "a_unique_id");
+        using (var client = new MonzoClient(httpClient, "testAccessToken"))
+        {
+            var updatedPot = await client.WithdrawFromPotAsync("pot_00009exampleP0tOxWb", "test_account_123", 500, "a_unique_id");
 
-                Assert.NotNull(updatedPot);
+            Assert.NotNull(updatedPot);
 
-                Assert.AreEqual("pot_00009exampleP0tOxWb", updatedPot.Id);
-                Assert.AreEqual("Flying Lessons", updatedPot.Name);
-                Assert.AreEqual("blue", updatedPot.Style);
-                Assert.AreEqual(350000, updatedPot.Balance);
-                Assert.AreEqual("GBP", updatedPot.Currency);
-                Assert.AreEqual("test_account_123", updatedPot.CurrentAccountId);
-                Assert.AreEqual(new DateTime(2017, 11, 9, 12, 30, 53, 695, DateTimeKind.Utc), updatedPot.Created);
-                Assert.AreEqual(new DateTime(2018, 2, 26, 7, 12, 4, 925, DateTimeKind.Utc), updatedPot.Updated);
-                Assert.AreEqual(false, updatedPot.Deleted);
-            }
-
-            Assert.AreEqual("Bearer testAccessToken", fakeMessageHandler.Request.Headers.Authorization.ToString());
-            Assert.AreEqual("PUT", fakeMessageHandler.Request.Method.ToString());
-            Assert.AreEqual("/pots/pot_00009exampleP0tOxWb/withdraw", fakeMessageHandler.Request.RequestUri.PathAndQuery);
-
-            var formCollection = await fakeMessageHandler.GetQueryStringAsync();
-
-            Assert.AreEqual("test_account_123", formCollection["destination_account_id"]);
-            Assert.AreEqual("500", formCollection["amount"]);
-            Assert.AreEqual("a_unique_id", formCollection["dedupe_id"]);
+            Assert.AreEqual("pot_00009exampleP0tOxWb", updatedPot.Id);
+            Assert.AreEqual("Flying Lessons", updatedPot.Name);
+            Assert.AreEqual("blue", updatedPot.Style);
+            Assert.AreEqual(350000, updatedPot.Balance);
+            Assert.AreEqual("GBP", updatedPot.Currency);
+            Assert.AreEqual("test_account_123", updatedPot.CurrentAccountId);
+            Assert.AreEqual(new DateTime(2017, 11, 9, 12, 30, 53, 695, DateTimeKind.Utc), updatedPot.Created);
+            Assert.AreEqual(new DateTime(2018, 2, 26, 7, 12, 4, 925, DateTimeKind.Utc), updatedPot.Updated);
+            Assert.AreEqual(false, updatedPot.Deleted);
         }
+
+        Assert.AreEqual("Bearer testAccessToken", fakeMessageHandler.Request.Headers.Authorization!.ToString());
+        Assert.AreEqual("PUT", fakeMessageHandler.Request.Method.ToString());
+        Assert.AreEqual("/pots/pot_00009exampleP0tOxWb/withdraw", fakeMessageHandler.Request.RequestUri!.PathAndQuery);
+
+        var formCollection = await fakeMessageHandler.GetQueryStringAsync();
+
+        Assert.AreEqual("test_account_123", formCollection["destination_account_id"]);
+        Assert.AreEqual("500", formCollection["amount"]);
+        Assert.AreEqual("a_unique_id", formCollection["dedupe_id"]);
     }
 }

--- a/Monzo.Tests/MonzoClientTests/Transactions.cs
+++ b/Monzo.Tests/MonzoClientTests/Transactions.cs
@@ -1,21 +1,21 @@
-﻿namespace Monzo.Tests.MonzoClientTests
+﻿namespace Monzo.Tests.MonzoClientTests;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Fakes;
+using NUnit.Framework;
+
+[TestFixture]
+public sealed class Transactions
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Net;
-    using System.Threading.Tasks;
-    using Monzo.Tests.Fakes;
-    using NUnit.Framework;
-
-    [TestFixture]
-    public sealed class Transactions
+    [Test]
+    public async Task CanGetTransactions()
     {
-        [Test]
-        public async Task CanGetTransactions()
-        {
-            var (httpClient, fakeMessageHandler) = FakeHttpClientFactory.Create(HttpStatusCode.OK,
-                @"{
+        var (httpClient, fakeMessageHandler) = FakeHttpClientFactory.Create(HttpStatusCode.OK,
+            @"{
                     'transactions': [
                         {
                             'account_balance': 13013,
@@ -49,35 +49,35 @@
                 }");
 
 
-            using (var client = new MonzoClient(httpClient, "testAccessToken"))
-            {
-                var transactions = await client.GetTransactionsAsync("1");
+        using (var client = new MonzoClient(httpClient, "testAccessToken"))
+        {
+            var transactions = await client.GetTransactionsAsync("1");
 
-                Assert.AreEqual(2, transactions.Count);
+            Assert.AreEqual(2, transactions.Count);
 
-                Assert.AreEqual(13013, transactions[0].AccountBalance);
-                Assert.AreEqual(-510, transactions[0].Amount);
-                Assert.AreEqual(new DateTime(2015, 08, 22, 12, 20, 18, DateTimeKind.Utc), transactions[0].Created);
-                Assert.AreEqual("GBP", transactions[0].Currency);
-                Assert.AreEqual("THE DE BEAUVOIR DELI C LONDON        GBR", transactions[0].Description);
-                Assert.AreEqual("tx_00008zIcpb1TB4yeIFXMzx", transactions[0].Id);
-                Assert.AreEqual("merch_00008zIcpbAKe8shBxXUtl", transactions[0].Merchant.Id);
-                Assert.AreEqual(new Dictionary<string, string>(), transactions[0].Metadata);
-                Assert.AreEqual("Salmon sandwich 🍞", transactions[0].Notes);
-                Assert.IsFalse(transactions[0].IsLoad);
-                Assert.AreEqual("eating_out", transactions[0].Category);
-            }
-
-            Assert.AreEqual("/transactions?account_id=1", fakeMessageHandler.Request.RequestUri.PathAndQuery);
-
-            Assert.AreEqual("Bearer testAccessToken", fakeMessageHandler.Request.Headers.Authorization.ToString());
+            Assert.AreEqual(13013, transactions[0].AccountBalance);
+            Assert.AreEqual(-510, transactions[0].Amount);
+            Assert.AreEqual(new DateTime(2015, 08, 22, 12, 20, 18, DateTimeKind.Utc), transactions[0].Created);
+            Assert.AreEqual("GBP", transactions[0].Currency);
+            Assert.AreEqual("THE DE BEAUVOIR DELI C LONDON        GBR", transactions[0].Description);
+            Assert.AreEqual("tx_00008zIcpb1TB4yeIFXMzx", transactions[0].Id);
+            Assert.AreEqual("merch_00008zIcpbAKe8shBxXUtl", transactions[0].Merchant.Id);
+            Assert.AreEqual(new Dictionary<string, string>(), transactions[0].Metadata);
+            Assert.AreEqual("Salmon sandwich 🍞", transactions[0].Notes);
+            Assert.IsFalse(transactions[0].IsLoad);
+            Assert.AreEqual("eating_out", transactions[0].Category);
         }
 
-        [Test]
-        public async Task CanGetTransactionsPaginated()
-        {
-            var (httpClient, fakeMessageHandler) = FakeHttpClientFactory.Create(HttpStatusCode.OK,
-                @"{
+        Assert.AreEqual("/transactions?account_id=1", fakeMessageHandler.Request.RequestUri!.PathAndQuery);
+
+        Assert.AreEqual("Bearer testAccessToken", fakeMessageHandler.Request.Headers.Authorization!.ToString());
+    }
+
+    [Test]
+    public async Task CanGetTransactionsPaginated()
+    {
+        var (httpClient, fakeMessageHandler) = FakeHttpClientFactory.Create(HttpStatusCode.OK,
+            @"{
                     'transactions': [
                         {
                             'account_balance': 13013,
@@ -110,35 +110,41 @@
                     ]
                 }");
 
-            using (var client = new MonzoClient(httpClient, "testAccessToken"))
-            {
-                var transactions = await client.GetTransactionsAsync("1", null, new PaginationOptions { SinceTime = new DateTime(2015, 4, 5, 18, 1, 32, DateTimeKind.Utc), Limit = 40, BeforeTime = new DateTime(2015, 12, 25, 18, 1, 32, DateTimeKind.Utc) });
+        using (var client = new MonzoClient(httpClient, "testAccessToken"))
+        {
+            var transactions = await client.GetTransactionsAsync("1", null,
+                new PaginationOptions
+                {
+                    SinceTime = new DateTime(2015, 4, 5, 18, 1, 32, DateTimeKind.Utc), Limit = 40,
+                    BeforeTime = new DateTime(2015, 12, 25, 18, 1, 32, DateTimeKind.Utc)
+                });
 
-                Assert.AreEqual(2, transactions.Count);
+            Assert.AreEqual(2, transactions.Count);
 
-                Assert.AreEqual(13013, transactions[0].AccountBalance);
-                Assert.AreEqual(-510, transactions[0].Amount);
-                Assert.AreEqual(new DateTime(2015, 08, 22, 12, 20, 18, DateTimeKind.Utc), transactions[0].Created);
-                Assert.AreEqual("GBP", transactions[0].Currency);
-                Assert.AreEqual("THE DE BEAUVOIR DELI C LONDON        GBR", transactions[0].Description);
-                Assert.AreEqual("tx_00008zIcpb1TB4yeIFXMzx", transactions[0].Id);
-                Assert.AreEqual("merch_00008zIcpbAKe8shBxXUtl", transactions[0].Merchant.Id);
-                Assert.AreEqual(new Dictionary<string, string>(), transactions[0].Metadata);
-                Assert.AreEqual("Salmon sandwich 🍞", transactions[0].Notes);
-                Assert.IsFalse(transactions[0].IsLoad);
-                Assert.AreEqual("eating_out", transactions[0].Category);
-            }
-
-            Assert.AreEqual("/transactions?account_id=1&limit=40&since=2015-04-05T18:01:32Z&before=2015-12-25T18:01:32Z", fakeMessageHandler.Request.RequestUri.PathAndQuery);
-
-            Assert.AreEqual("Bearer testAccessToken", fakeMessageHandler.Request.Headers.Authorization.ToString());
+            Assert.AreEqual(13013, transactions[0].AccountBalance);
+            Assert.AreEqual(-510, transactions[0].Amount);
+            Assert.AreEqual(new DateTime(2015, 08, 22, 12, 20, 18, DateTimeKind.Utc), transactions[0].Created);
+            Assert.AreEqual("GBP", transactions[0].Currency);
+            Assert.AreEqual("THE DE BEAUVOIR DELI C LONDON        GBR", transactions[0].Description);
+            Assert.AreEqual("tx_00008zIcpb1TB4yeIFXMzx", transactions[0].Id);
+            Assert.AreEqual("merch_00008zIcpbAKe8shBxXUtl", transactions[0].Merchant.Id);
+            Assert.AreEqual(new Dictionary<string, string>(), transactions[0].Metadata);
+            Assert.AreEqual("Salmon sandwich 🍞", transactions[0].Notes);
+            Assert.IsFalse(transactions[0].IsLoad);
+            Assert.AreEqual("eating_out", transactions[0].Category);
         }
 
-        [Test]
-        public async Task CanGetTransaction()
-        {
-            var (httpClient, fakeMessageHandler) = FakeHttpClientFactory.Create(HttpStatusCode.OK,
-                @"{
+        Assert.AreEqual("/transactions?account_id=1&limit=40&since=2015-04-05T18:01:32Z&before=2015-12-25T18:01:32Z",
+            fakeMessageHandler.Request.RequestUri!.PathAndQuery);
+
+        Assert.AreEqual("Bearer testAccessToken", fakeMessageHandler.Request.Headers.Authorization!.ToString());
+    }
+
+    [Test]
+    public async Task CanGetTransaction()
+    {
+        var (httpClient, fakeMessageHandler) = FakeHttpClientFactory.Create(HttpStatusCode.OK,
+            @"{
                     'transaction': {
                         'account_balance': 13013,
                         'amount': -510,
@@ -154,34 +160,34 @@
                     }
                 }");
 
-            using (var client = new MonzoClient(httpClient, "testAccessToken"))
-            {
-                var transaction = await client.GetTransactionAsync("1");
+        using (var client = new MonzoClient(httpClient, "testAccessToken"))
+        {
+            var transaction = await client.GetTransactionAsync("1");
 
-                Assert.AreEqual(13013, transaction.AccountBalance);
-                Assert.AreEqual(-510, transaction.Amount);
-                Assert.AreEqual(new DateTime(2015, 8, 22, 12, 20, 18, DateTimeKind.Utc), transaction.Created);
-                Assert.AreEqual("GBP", transaction.Currency);
-                Assert.AreEqual("THE DE BEAUVOIR DELI C LONDON        GBR", transaction.Description);
-                Assert.AreEqual("tx_00008zIcpb1TB4yeIFXMzx", transaction.Id);
-                Assert.AreEqual(new Dictionary<string, string>(), transaction.Metadata);
-                Assert.AreEqual("Salmon sandwich 🍞", transaction.Notes);
-                Assert.IsFalse(transaction.IsLoad);
+            Assert.AreEqual(13013, transaction.AccountBalance);
+            Assert.AreEqual(-510, transaction.Amount);
+            Assert.AreEqual(new DateTime(2015, 8, 22, 12, 20, 18, DateTimeKind.Utc), transaction.Created);
+            Assert.AreEqual("GBP", transaction.Currency);
+            Assert.AreEqual("THE DE BEAUVOIR DELI C LONDON        GBR", transaction.Description);
+            Assert.AreEqual("tx_00008zIcpb1TB4yeIFXMzx", transaction.Id);
+            Assert.AreEqual(new Dictionary<string, string>(), transaction.Metadata);
+            Assert.AreEqual("Salmon sandwich 🍞", transaction.Notes);
+            Assert.IsFalse(transaction.IsLoad);
 
-                Assert.AreEqual("merch_00008zIcpbAKe8shBxXUtl", transaction.Merchant.Id);
-            }
-
-
-            Assert.AreEqual("/transactions/1", fakeMessageHandler.Request.RequestUri.PathAndQuery);
-
-            Assert.AreEqual("Bearer testAccessToken", fakeMessageHandler.Request.Headers.Authorization.ToString());
+            Assert.AreEqual("merch_00008zIcpbAKe8shBxXUtl", transaction.Merchant.Id);
         }
 
-        [Test]
-        public async Task CanGetTransactionExpanded()
-        {
-            var (httpClient, fakeMessageHandler) = FakeHttpClientFactory.Create(HttpStatusCode.OK,
-                @"{
+
+        Assert.AreEqual("/transactions/1", fakeMessageHandler.Request.RequestUri!.PathAndQuery);
+
+        Assert.AreEqual("Bearer testAccessToken", fakeMessageHandler.Request.Headers.Authorization!.ToString());
+    }
+
+    [Test]
+    public async Task CanGetTransactionExpanded()
+    {
+        var (httpClient, fakeMessageHandler) = FakeHttpClientFactory.Create(HttpStatusCode.OK,
+            @"{
                     'transaction': {
                         'account_balance': 13013,
                         'amount': -510,
@@ -214,46 +220,46 @@
                     }
                 }");
 
-            using (var client = new MonzoClient(httpClient, "testAccessToken"))
-            {
-                var transaction = await client.GetTransactionAsync("1", "merchant");
+        using (var client = new MonzoClient(httpClient, "testAccessToken"))
+        {
+            var transaction = await client.GetTransactionAsync("1", "merchant");
 
-                Assert.AreEqual(13013, transaction.AccountBalance);
-                Assert.AreEqual(-510, transaction.Amount);
-                Assert.AreEqual(new DateTime(2015, 8, 22, 12, 20, 18, DateTimeKind.Utc), transaction.Created);
-                Assert.AreEqual("GBP", transaction.Currency);
-                Assert.AreEqual("THE DE BEAUVOIR DELI C LONDON        GBR", transaction.Description);
-                Assert.AreEqual("tx_00008zIcpb1TB4yeIFXMzx", transaction.Id);
-                Assert.AreEqual(new Dictionary<string, string>(), transaction.Metadata);
-                Assert.AreEqual("Salmon sandwich 🍞", transaction.Notes);
-                Assert.IsFalse(transaction.IsLoad);
+            Assert.AreEqual(13013, transaction.AccountBalance);
+            Assert.AreEqual(-510, transaction.Amount);
+            Assert.AreEqual(new DateTime(2015, 8, 22, 12, 20, 18, DateTimeKind.Utc), transaction.Created);
+            Assert.AreEqual("GBP", transaction.Currency);
+            Assert.AreEqual("THE DE BEAUVOIR DELI C LONDON        GBR", transaction.Description);
+            Assert.AreEqual("tx_00008zIcpb1TB4yeIFXMzx", transaction.Id);
+            Assert.AreEqual(new Dictionary<string, string>(), transaction.Metadata);
+            Assert.AreEqual("Salmon sandwich 🍞", transaction.Notes);
+            Assert.IsFalse(transaction.IsLoad);
 
-                Assert.AreEqual("98 Southgate Road", transaction.Merchant.Address.Address);
-                Assert.AreEqual("London", transaction.Merchant.Address.City);
-                Assert.AreEqual(51.54151, transaction.Merchant.Address.Latitude);
-                Assert.AreEqual(-0.08482400000002599, transaction.Merchant.Address.Longitude);
-                Assert.AreEqual("N1 3JD", transaction.Merchant.Address.Postcode);
-                Assert.AreEqual("Greater London", transaction.Merchant.Address.Region);
+            Assert.AreEqual("98 Southgate Road", transaction.Merchant.Address.Address);
+            Assert.AreEqual("London", transaction.Merchant.Address.City);
+            Assert.AreEqual(51.54151, transaction.Merchant.Address.Latitude);
+            Assert.AreEqual(-0.08482400000002599, transaction.Merchant.Address.Longitude);
+            Assert.AreEqual("N1 3JD", transaction.Merchant.Address.Postcode);
+            Assert.AreEqual("Greater London", transaction.Merchant.Address.Region);
 
-                Assert.AreEqual(new DateTime(2015, 8, 22, 12, 20, 18, DateTimeKind.Utc), transaction.Merchant.Created);
-                Assert.AreEqual("grp_00008zIcpbBOaAr7TTP3sv", transaction.Merchant.GroupId);
-                Assert.AreEqual("merch_00008zIcpbAKe8shBxXUtl", transaction.Merchant.Id);
-                Assert.AreEqual("https://pbs.twimg.com/profile_images/527043602623389696/68_SgUWJ.jpeg", transaction.Merchant.Logo);
-                Assert.AreEqual("🍞", transaction.Merchant.Emoji);
-                Assert.AreEqual("The De Beauvoir Deli Co.", transaction.Merchant.Name);
-                Assert.AreEqual("eating_out", transaction.Merchant.Category);
-            }
-
-            Assert.AreEqual("/transactions/1?expand[]=merchant", fakeMessageHandler.Request.RequestUri.PathAndQuery);
-
-            Assert.AreEqual("Bearer testAccessToken", fakeMessageHandler.Request.Headers.Authorization.ToString());
+            Assert.AreEqual(new DateTime(2015, 8, 22, 12, 20, 18, DateTimeKind.Utc), transaction.Merchant.Created);
+            Assert.AreEqual("grp_00008zIcpbBOaAr7TTP3sv", transaction.Merchant.GroupId);
+            Assert.AreEqual("merch_00008zIcpbAKe8shBxXUtl", transaction.Merchant.Id);
+            Assert.AreEqual("https://pbs.twimg.com/profile_images/527043602623389696/68_SgUWJ.jpeg", transaction.Merchant.Logo);
+            Assert.AreEqual("🍞", transaction.Merchant.Emoji);
+            Assert.AreEqual("The De Beauvoir Deli Co.", transaction.Merchant.Name);
+            Assert.AreEqual("eating_out", transaction.Merchant.Category);
         }
 
-        [Test]
-        public async Task CanGetBankTransfer()
-        {
-            var (httpClient, fakeMessageHandler) = FakeHttpClientFactory.Create(HttpStatusCode.OK,
-                @"{
+        Assert.AreEqual("/transactions/1?expand[]=merchant", fakeMessageHandler.Request.RequestUri!.PathAndQuery);
+
+        Assert.AreEqual("Bearer testAccessToken", fakeMessageHandler.Request.Headers.Authorization!.ToString());
+    }
+
+    [Test]
+    public async Task CanGetBankTransfer()
+    {
+        var (httpClient, fakeMessageHandler) = FakeHttpClientFactory.Create(HttpStatusCode.OK,
+            @"{
                     'transaction': {
                         'id': 'tx_0000000000000000000001',
                         'created': '2017-11-11T14:40:22.354Z',
@@ -295,30 +301,30 @@
                     }
                 }");
 
-            using (var client = new MonzoClient(httpClient, "testAccessToken"))
-            {
-                var transaction = await client.GetTransactionAsync("1", "merchant");
+        using (var client = new MonzoClient(httpClient, "testAccessToken"))
+        {
+            var transaction = await client.GetTransactionAsync("1", "merchant");
 
-                Assert.AreEqual(10000, transaction.Amount);
-                Assert.AreEqual("general", transaction.Category);
-                Assert.AreEqual(false, transaction.IncludeInSpending);
-                Assert.AreEqual(false, transaction.IsLoad);
-                Assert.AreEqual("12345678", transaction.CounterParty.AccountNumber);
-                Assert.AreEqual("Paddington Bear", transaction.CounterParty.Name);
-                Assert.AreEqual("040004", transaction.CounterParty.SortCode);
-                Assert.AreEqual("anonuser_0000000000000000000001", transaction.CounterParty.UserId);
-            }
-
-            Assert.AreEqual("/transactions/1?expand[]=merchant", fakeMessageHandler.Request.RequestUri.PathAndQuery);
-
-            Assert.AreEqual("Bearer testAccessToken", fakeMessageHandler.Request.Headers.Authorization.ToString());
+            Assert.AreEqual(10000, transaction.Amount);
+            Assert.AreEqual("general", transaction.Category);
+            Assert.AreEqual(false, transaction.IncludeInSpending);
+            Assert.AreEqual(false, transaction.IsLoad);
+            Assert.AreEqual("12345678", transaction.CounterParty.AccountNumber);
+            Assert.AreEqual("Paddington Bear", transaction.CounterParty.Name);
+            Assert.AreEqual("040004", transaction.CounterParty.SortCode);
+            Assert.AreEqual("anonuser_0000000000000000000001", transaction.CounterParty.UserId);
         }
 
-        [Test]
-        public async Task CanAnnotateTransaction()
-        {
-            var (httpClient, fakeMessageHandler) = FakeHttpClientFactory.Create(HttpStatusCode.OK,
-                @"{
+        Assert.AreEqual("/transactions/1?expand[]=merchant", fakeMessageHandler.Request.RequestUri!.PathAndQuery);
+
+        Assert.AreEqual("Bearer testAccessToken", actual: fakeMessageHandler.Request.Headers.Authorization!.ToString());
+    }
+
+    [Test]
+    public async Task CanAnnotateTransaction()
+    {
+        var (httpClient, fakeMessageHandler) = FakeHttpClientFactory.Create(HttpStatusCode.OK,
+            @"{
                     'transaction': {
                         'account_balance': 12334,
                         'amount': -679,
@@ -337,22 +343,21 @@
                     }
                 }");
 
-            using (var client = new MonzoClient(httpClient, "testAccessToken"))
-            {
-                var transaction = await client.AnnotateTransactionAsync("1", new Dictionary<string, string> { { "key1", "value1" }, { "key2", "" } });
+        using (var client = new MonzoClient(httpClient, "testAccessToken"))
+        {
+            var transaction = await client.AnnotateTransactionAsync("1", new Dictionary<string, string> { { "key1", "value1" }, { "key2", "" } });
 
-                Assert.AreEqual("foo", transaction.Metadata.First().Key);
-                Assert.AreEqual("bar", transaction.Metadata.First().Value);
-            }
-
-            Assert.AreEqual("Bearer testAccessToken", fakeMessageHandler.Request.Headers.Authorization.ToString());
-            Assert.AreEqual("PATCH", fakeMessageHandler.Request.Method.ToString());
-            Assert.AreEqual("/transactions/1", fakeMessageHandler.Request.RequestUri.PathAndQuery);
-
-            var formCollection = await fakeMessageHandler.GetQueryStringAsync();
-
-            Assert.AreEqual("value1", formCollection["metadata[key1]"]);
-            Assert.AreEqual("", formCollection["metadata[key2]"]);
+            Assert.AreEqual("foo", transaction.Metadata.First().Key);
+            Assert.AreEqual("bar", transaction.Metadata.First().Value);
         }
+
+        Assert.AreEqual("Bearer testAccessToken", fakeMessageHandler.Request.Headers.Authorization!.ToString());
+        Assert.AreEqual("PATCH", fakeMessageHandler.Request.Method.ToString());
+        Assert.AreEqual("/transactions/1", fakeMessageHandler.Request.RequestUri!.PathAndQuery);
+
+        var formCollection = await fakeMessageHandler.GetQueryStringAsync();
+
+        Assert.AreEqual("value1", formCollection["metadata[key1]"]);
+        Assert.AreEqual("", formCollection["metadata[key2]"]);
     }
 }

--- a/Monzo.Tests/MonzoClientTests/Webhooks.cs
+++ b/Monzo.Tests/MonzoClientTests/Webhooks.cs
@@ -1,18 +1,18 @@
-﻿namespace Monzo.Tests.MonzoClientTests
-{
-    using Monzo.Tests.Fakes;
-    using NUnit.Framework;
-    using System.Net;
-    using System.Threading.Tasks;
+﻿namespace Monzo.Tests.MonzoClientTests;
 
-    [TestFixture]
-    public sealed class Webhooks
+using Fakes;
+using NUnit.Framework;
+using System.Net;
+using System.Threading.Tasks;
+
+[TestFixture]
+public sealed class Webhooks
+{
+    [Test]
+    public async Task CanCreateWebhook()
     {
-        [Test]
-        public async Task CanCreateWebhook()
-        {
-            var (httpClient, fakeMessageHandler) = FakeHttpClientFactory.Create(HttpStatusCode.OK,
-                @"{
+        var (httpClient, fakeMessageHandler) = FakeHttpClientFactory.Create(HttpStatusCode.OK,
+            @"{
                     'webhook': {
                         'account_id': 'account_id',
                         'id': 'webhook_id',
@@ -20,29 +20,29 @@
                     }
                 }");
 
-            using (var client = new MonzoClient(httpClient, "testAccessToken"))
-            {
-                var webhook = await client.CreateWebhookAsync("1", "http://example.com");
+        using (var client = new MonzoClient(httpClient, "testAccessToken"))
+        {
+            var webhook = await client.CreateWebhookAsync("1", "http://example.com");
 
-                Assert.AreEqual("account_id", webhook.AccountId);
-                Assert.AreEqual("webhook_id", webhook.Id);
-                Assert.AreEqual("http://example.com", webhook.Url);
-            }
-
-            Assert.AreEqual("Bearer testAccessToken", fakeMessageHandler.Request.Headers.Authorization.ToString());
-            Assert.AreEqual("POST", fakeMessageHandler.Request.Method.ToString());
-            Assert.AreEqual("/webhooks", fakeMessageHandler.Request.RequestUri.PathAndQuery);
-
-            var formCollection = await fakeMessageHandler.GetQueryStringAsync();
-            Assert.AreEqual("1", formCollection["account_id"]);
-            Assert.AreEqual("http://example.com", formCollection["url"]);
+            Assert.AreEqual("account_id", webhook.AccountId);
+            Assert.AreEqual("webhook_id", webhook.Id);
+            Assert.AreEqual("http://example.com", webhook.Url);
         }
 
-        [Test]
-        public async Task CanGetWebhooks()
-        {
-            var (httpClient, fakeMessageHandler) = FakeHttpClientFactory.Create(HttpStatusCode.OK,
-                @"{
+        Assert.AreEqual("Bearer testAccessToken", fakeMessageHandler.Request.Headers.Authorization!.ToString());
+        Assert.AreEqual("POST", fakeMessageHandler.Request.Method.ToString());
+        Assert.AreEqual("/webhooks", fakeMessageHandler.Request.RequestUri!.PathAndQuery);
+
+        var formCollection = await fakeMessageHandler.GetQueryStringAsync();
+        Assert.AreEqual("1", formCollection["account_id"]);
+        Assert.AreEqual("http://example.com", formCollection["url"]);
+    }
+
+    [Test]
+    public async Task CanGetWebhooks()
+    {
+        var (httpClient, fakeMessageHandler) = FakeHttpClientFactory.Create(HttpStatusCode.OK,
+            @"{
                     'webhooks': [
                         {
                             'account_id': 'acc_000091yf79yMwNaZHhHGzp',
@@ -52,35 +52,34 @@
                     ]
                 }");
 
-            using (var client = new MonzoClient(httpClient, "testAccessToken"))
-            {
-                var webhooks = await client.GetWebhooksAsync("1");
-
-                Assert.AreEqual(1, webhooks.Count);
-                Assert.AreEqual("webhook_000091yhhOmrXQaVZ1Irsv", webhooks[0].Id);
-                Assert.AreEqual("acc_000091yf79yMwNaZHhHGzp", webhooks[0].AccountId);
-                Assert.AreEqual("http://example.com/callback", webhooks[0].Url);
-            }
-
-            Assert.AreEqual("/webhooks?account_id=1", fakeMessageHandler.Request.RequestUri.PathAndQuery);
-
-            Assert.AreEqual("Bearer testAccessToken", fakeMessageHandler.Request.Headers.Authorization.ToString());
-        }
-
-        [Test]
-        public async Task CanDeleteWebhook()
+        using (var client = new MonzoClient(httpClient, "testAccessToken"))
         {
-            var (httpClient, fakeMessageHandler) = FakeHttpClientFactory.Create(HttpStatusCode.OK, "{}");
+            var webhooks = await client.GetWebhooksAsync("1");
 
-            using (var client = new MonzoClient(httpClient, "testAccessToken"))
-            {
-                await client.DeleteWebhookAsync("1");
-            }
-
-            Assert.AreEqual("/webhooks/1", fakeMessageHandler.Request.RequestUri.PathAndQuery);
-            Assert.AreEqual("DELETE", fakeMessageHandler.Request.Method.ToString());
-
-            Assert.AreEqual("Bearer testAccessToken", fakeMessageHandler.Request.Headers.Authorization.ToString());
+            Assert.AreEqual(1, webhooks.Count);
+            Assert.AreEqual("webhook_000091yhhOmrXQaVZ1Irsv", webhooks[0].Id);
+            Assert.AreEqual("acc_000091yf79yMwNaZHhHGzp", webhooks[0].AccountId);
+            Assert.AreEqual("http://example.com/callback", webhooks[0].Url);
         }
+
+        Assert.AreEqual("/webhooks?account_id=1", fakeMessageHandler.Request.RequestUri!.PathAndQuery);
+
+        Assert.AreEqual("Bearer testAccessToken", fakeMessageHandler.Request.Headers.Authorization!.ToString());
+    }
+
+    [Test]
+    public async Task CanDeleteWebhook()
+    {
+        var (httpClient, fakeMessageHandler) = FakeHttpClientFactory.Create(HttpStatusCode.OK, "{}");
+
+        using (var client = new MonzoClient(httpClient, "testAccessToken"))
+        {
+            await client.DeleteWebhookAsync("1");
+        }
+
+        Assert.AreEqual("/webhooks/1", fakeMessageHandler.Request.RequestUri!.PathAndQuery);
+        Assert.AreEqual("DELETE", fakeMessageHandler.Request.Method.ToString());
+
+        Assert.AreEqual("Bearer testAccessToken", fakeMessageHandler.Request.Headers.Authorization!.ToString());
     }
 }

--- a/Monzo.Tests/MonzoClientTests/WhoAmI.cs
+++ b/Monzo.Tests/MonzoClientTests/WhoAmI.cs
@@ -1,36 +1,35 @@
-﻿namespace Monzo.Tests.MonzoClientTests
-{
-    using Monzo.Tests.Fakes;
-    using NUnit.Framework;
-    using System.Net;
-    using System.Threading.Tasks;
+﻿namespace Monzo.Tests.MonzoClientTests;
 
-    [TestFixture]
-    public sealed class WhoAmI
+using Fakes;
+using NUnit.Framework;
+using System.Net;
+using System.Threading.Tasks;
+
+[TestFixture]
+public sealed class WhoAmI
+{
+    [Test]
+    public async Task CanGetWhoAmI()
     {
-        [Test]
-        public async Task CanGetWhoAmI()
-        {
-            var (httpClient, fakeMessageHandler) = FakeHttpClientFactory.Create(HttpStatusCode.OK,
-                @"{
+        var (httpClient, fakeMessageHandler) = FakeHttpClientFactory.Create(HttpStatusCode.OK,
+            @"{
                     'authenticated': true,
                     'client_id': 'oauth_abc123',
                     'user_id': 'user_00009238aMBIIrS5Rdncq9',
                 }");
 
 
-            using (var client = new MonzoClient(httpClient, "testAccessToken"))
-            {
-                var response = await client.WhoAmIAsync();
+        using (var client = new MonzoClient(httpClient, "testAccessToken"))
+        {
+            var response = await client.WhoAmIAsync();
 
-                Assert.AreEqual(true, response.Authenticated);
-                Assert.AreEqual("oauth_abc123", response.ClientId);
-                Assert.AreEqual("user_00009238aMBIIrS5Rdncq9", response.UserId);
-            }
-
-            Assert.AreEqual("/ping/whoami", fakeMessageHandler.Request.RequestUri.PathAndQuery);
-
-            Assert.AreEqual("Bearer testAccessToken", fakeMessageHandler.Request.Headers.Authorization.ToString());
+            Assert.AreEqual(true, response.Authenticated);
+            Assert.AreEqual("oauth_abc123", response.ClientId);
+            Assert.AreEqual("user_00009238aMBIIrS5Rdncq9", response.UserId);
         }
+
+        Assert.AreEqual("/ping/whoami", fakeMessageHandler.Request.RequestUri!.PathAndQuery);
+
+        Assert.AreEqual("Bearer testAccessToken", fakeMessageHandler.Request.Headers.Authorization!.ToString());
     }
 }

--- a/Monzo.Tests/PaginationOptionsTests.cs
+++ b/Monzo.Tests/PaginationOptionsTests.cs
@@ -1,33 +1,32 @@
 ﻿using System;
 using NUnit.Framework;
 
-namespace Monzo.Tests
+namespace Monzo.Tests;
+
+[TestFixture]
+public sealed class PaginationOptionsTests
 {
-    [TestFixture]
-    public sealed class PaginationOptionsTests
+    [Test]
+    public void SinceTime()
     {
-        [Test]
-        public void SinceTime()
-        {
-            Assert.AreEqual("&limit=&since=2015-04-05T18:01:32Z&before=", new PaginationOptions { SinceTime = new DateTime(2015, 4, 5, 18, 1, 32, DateTimeKind.Utc) }.ToString());
-        }
+        Assert.AreEqual("&limit=&since=2015-04-05T18:01:32Z&before=", new PaginationOptions { SinceTime = new DateTime(2015, 4, 5, 18, 1, 32, DateTimeKind.Utc) }.ToString());
+    }
 
-        [Test]
-        public void BeforeTime()
-        {
-            Assert.AreEqual("&limit=&since=&before=2015-04-05T18:01:32Z", new PaginationOptions { BeforeTime = new DateTime(2015, 4, 5, 18, 1, 32, DateTimeKind.Utc) }.ToString());
-        }
+    [Test]
+    public void BeforeTime()
+    {
+        Assert.AreEqual("&limit=&since=&before=2015-04-05T18:01:32Z", new PaginationOptions { BeforeTime = new DateTime(2015, 4, 5, 18, 1, 32, DateTimeKind.Utc) }.ToString());
+    }
 
-        [Test]
-        public void SinceId()
-        {
-            Assert.AreEqual("&limit=&since=1&before=", new PaginationOptions { SinceId = "1" }.ToString());
-        }
+    [Test]
+    public void SinceId()
+    {
+        Assert.AreEqual("&limit=&since=1&before=", new PaginationOptions { SinceId = "1" }.ToString());
+    }
 
-        [Test]
-        public void Limit()
-        {
-            Assert.AreEqual("&limit=100&since=&before=", new PaginationOptions { Limit = 100 }.ToString());
-        }
+    [Test]
+    public void Limit()
+    {
+        Assert.AreEqual("&limit=100&since=&before=", new PaginationOptions { Limit = 100 }.ToString());
     }
 }

--- a/Monzo.sln.DotSettings
+++ b/Monzo.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Monzo/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/Monzo/AccessToken.cs
+++ b/Monzo/AccessToken.cs
@@ -1,48 +1,47 @@
 ﻿using System.Diagnostics;
 using Newtonsoft.Json;
 
-namespace Monzo
+namespace Monzo;
+
+/// <summary>
+/// Monzo access token response.
+/// </summary>
+[DebuggerDisplay("[{Value,nq}]")]
+public sealed class AccessToken
 {
     /// <summary>
-    /// Monzo access token response.
+    /// The Access Token to use for requests.
     /// </summary>
-    [DebuggerDisplay("[{Value,nq}]")]
-    public sealed class AccessToken
-    {
-        /// <summary>
-        /// The Access Token to use for requests.
-        /// </summary>
-        [JsonProperty(PropertyName = "access_token")]
-        public string Value { get; set; }
+    [JsonProperty(PropertyName = "access_token")]
+    public string Value { get; set; }
 
-        /// <summary>
-        /// Your client ID.
-        /// </summary>
-        [JsonProperty("client_id")]
-        public string ClientId { get; set; }
+    /// <summary>
+    /// Your client ID.
+    /// </summary>
+    [JsonProperty("client_id")]
+    public string ClientId { get; set; }
 
-        /// <summary>
-        /// The OAuth 2 token type.
-        /// </summary>
-        [JsonProperty(PropertyName = "token_type")]
-        public string TokenType { get; set; }
+    /// <summary>
+    /// The OAuth 2 token type.
+    /// </summary>
+    [JsonProperty(PropertyName = "token_type")]
+    public string TokenType { get; set; }
 
-        /// <summary>
-        /// Number of seconds before the token expires.
-        /// </summary>
-        [JsonProperty(PropertyName = "expires_in")]
-        public int ExpiresIn { get; set; }
+    /// <summary>
+    /// Number of seconds before the token expires.
+    /// </summary>
+    [JsonProperty(PropertyName = "expires_in")]
+    public int ExpiresIn { get; set; }
 
-        /// <summary>
-        /// The OAuth refresh token to use to grant a new access token.
-        /// </summary>
-        [JsonProperty(PropertyName = "refresh_token")]
-        public string RefreshToken { get; set; }
+    /// <summary>
+    /// The OAuth refresh token to use to grant a new access token.
+    /// </summary>
+    [JsonProperty(PropertyName = "refresh_token")]
+    public string RefreshToken { get; set; }
 
-        /// <summary>
-        /// The user ID.
-        /// </summary>
-        [JsonProperty(PropertyName = "user_id")]
-        public string UserId { get; set; }
-    }
+    /// <summary>
+    /// The user ID.
+    /// </summary>
+    [JsonProperty(PropertyName = "user_id")]
+    public string UserId { get; set; }
 }

--- a/Monzo/Account.cs
+++ b/Monzo/Account.cs
@@ -2,72 +2,71 @@ using System;
 using System.Diagnostics;
 using Newtonsoft.Json;
 
-namespace Monzo
+namespace Monzo;
+
+/// <summary>
+/// Accounts represent a store of funds, and have a list of transactions.
+/// </summary>
+[DebuggerDisplay("[{Id,nq} {Description}]")]
+public sealed class Account
 {
     /// <summary>
-    /// Accounts represent a store of funds, and have a list of transactions.
+    /// The id of the account.
     /// </summary>
-    [DebuggerDisplay("[{Id,nq} {Description}]")]
-    public sealed class Account
-    {
-        /// <summary>
-        /// The id of the account.
-        /// </summary>
-        [JsonProperty("id")]
-        public string Id { get; set; }
+    [JsonProperty("id")]
+    public string Id { get; set; }
 
-        /// <summary>
-        /// The account description.
-        /// </summary>
-        [JsonProperty("description")]
-        public string Description { get; set; }
+    /// <summary>
+    /// The account description.
+    /// </summary>
+    [JsonProperty("description")]
+    public string Description { get; set; }
 
-        /// <summary>
-        /// When the account was created.
-        /// </summary>
-        [JsonProperty("created")]
-        public DateTime Created { get; set; }
+    /// <summary>
+    /// When the account was created.
+    /// </summary>
+    [JsonProperty("created")]
+    public DateTime Created { get; set; }
 
-        /// <summary>
-        /// If the account is prepaid or a current account.
-        /// </summary>
-        [JsonProperty("type")]
-        public AccountType Type { get; set; }
+    /// <summary>
+    /// If the account is prepaid or a current account.
+    /// </summary>
+    [JsonProperty("type")]
+    public AccountType Type { get; set; }
 
-        /// <summary>
-        /// Sort code for the account.
-        /// </summary>
-        [JsonProperty("sort_code")]
-        public string SortCode { get; set; }
+    /// <summary>
+    /// Sort code for the account.
+    /// </summary>
+    [JsonProperty("sort_code")]
+    public string SortCode { get; set; }
 
-        /// <summary>
-        /// Unique account number.
-        /// </summary>
-        [JsonProperty("account_number")]
-        public string AccountNumber { get; set; }
+    /// <summary>
+    /// Unique account number.
+    /// </summary>
+    [JsonProperty("account_number")]
+    public string AccountNumber { get; set; }
 
-        /// <summary>
-        /// Flag for if the account has been closed.
-        /// </summary>
-        [JsonProperty("closed")]
-        public bool Closed { get; set; }
+    /// <summary>
+    /// Flag for if the account has been closed.
+    /// </summary>
+    [JsonProperty("closed")]
+    public bool Closed { get; set; }
 
-        /// <summary>
-        /// Currency of the account.
-        /// </summary>
-        [JsonProperty("currency")]
-        public string Currency { get; set; }
+    /// <summary>
+    /// Currency of the account.
+    /// </summary>
+    [JsonProperty("currency")]
+    public string Currency { get; set; }
 
-        /// <summary>
-        /// ISO Alpha-2 Country Code of the account.
-        /// </summary>
-        [JsonProperty("country_code")]
-        public string CountryCode { get; set; }
+    /// <summary>
+    /// ISO Alpha-2 Country Code of the account.
+    /// </summary>
+    [JsonProperty("country_code")]
+    public string CountryCode { get; set; }
 
-        /// <summary>
-        /// Owners of the account.
-        /// </summary>
-        [JsonProperty("owners")]
-        public User[] Owners { get; set; }
-    }
+    /// <summary>
+    /// Owners of the account.
+    /// </summary>
+    [JsonProperty("owners")]
+    public User[] Owners { get; set; }
 }

--- a/Monzo/AccountType.cs
+++ b/Monzo/AccountType.cs
@@ -1,13 +1,10 @@
-﻿using System;
+﻿namespace Monzo;
 
-namespace Monzo
+public enum AccountType
 {
-    public enum AccountType
-    {
-        uk_prepaid = 1,
-        uk_retail = 2,
-        uk_retail_joint = 3,
-        uk_loan = 4,
-        uk_monzo_flex = 5,
-    }
+    uk_prepaid = 1,
+    uk_retail = 2,
+    uk_retail_joint = 3,
+    uk_loan = 4,
+    uk_monzo_flex = 5,
 }

--- a/Monzo/Attachment.cs
+++ b/Monzo/Attachment.cs
@@ -2,48 +2,47 @@ using System;
 using System.Diagnostics;
 using Newtonsoft.Json;
 
-namespace Monzo
+namespace Monzo;
+
+/// <summary>
+/// Images (eg. receipts) can be attached to transactions by uploading these via the attachment API. Once an attachment is registered against a transaction, the image will be shown in the transaction detail screen within the Monzo app.
+/// </summary>
+[DebuggerDisplay("[{Id,nq}]")]
+public sealed class Attachment
 {
     /// <summary>
-    /// Images (eg. receipts) can be attached to transactions by uploading these via the attachment API. Once an attachment is registered against a transaction, the image will be shown in the transaction detail screen within the Monzo app.
+    /// The ID of the attachment. This can be used to deregister at a later date.
     /// </summary>
-    [DebuggerDisplay("[{Id,nq}]")]
-    public sealed class Attachment
-    {
-        /// <summary>
-        /// The ID of the attachment. This can be used to deregister at a later date.
-        /// </summary>
-        [JsonProperty("id")]
-        public string Id { get; set; }
+    [JsonProperty("id")]
+    public string Id { get; set; }
 
-        /// <summary>
-        /// The id of the user who owns this attachment.
-        /// </summary>
-        [JsonProperty("user_id")]
-        public string UserId { get; set; }
+    /// <summary>
+    /// The id of the user who owns this attachment.
+    /// </summary>
+    [JsonProperty("user_id")]
+    public string UserId { get; set; }
 
-        /// <summary>
-        /// The id of the transaction to associate the attachment with.
-        /// </summary>
-        [JsonProperty("external_id")]
-        public string ExternalId { get; set; }
+    /// <summary>
+    /// The id of the transaction to associate the attachment with.
+    /// </summary>
+    [JsonProperty("external_id")]
+    public string ExternalId { get; set; }
 
-        /// <summary>
-        /// The URL of the uploaded attachment.
-        /// </summary>
-        [JsonProperty("file_url")]
-        public string FileUrl { get; set; }
+    /// <summary>
+    /// The URL of the uploaded attachment.
+    /// </summary>
+    [JsonProperty("file_url")]
+    public string FileUrl { get; set; }
 
-        /// <summary>
-        /// The content type of the attachment.
-        /// </summary>
-        [JsonProperty("file_type")]
-        public string FileType { get; set; }
+    /// <summary>
+    /// The content type of the attachment.
+    /// </summary>
+    [JsonProperty("file_type")]
+    public string FileType { get; set; }
 
-        /// <summary>
-        /// The timestamp in UTC when the attachment was created.
-        /// </summary>
-        [JsonProperty("created")]
-        public DateTime Created { get; set; }
-    }
+    /// <summary>
+    /// The timestamp in UTC when the attachment was created.
+    /// </summary>
+    [JsonProperty("created")]
+    public DateTime Created { get; set; }
 }

--- a/Monzo/Balance.cs
+++ b/Monzo/Balance.cs
@@ -1,30 +1,29 @@
 using System.Diagnostics;
 using Newtonsoft.Json;
 
-namespace Monzo
+namespace Monzo;
+
+/// <summary>
+/// Information about an accountâ€™s balance.
+/// </summary>
+[DebuggerDisplay("[{Value} {Currency,nq}]")]
+public sealed class Balance
 {
     /// <summary>
-    /// Information about an account’s balance.
+    /// The currently available balance of the account, as a 64bit integer in minor units of the currency, eg. pennies for GBP, or cents for EUR and USD.
     /// </summary>
-    [DebuggerDisplay("[{Balance} {Currency,nq}]")]
-    public sealed class Balance
-    {
-        /// <summary>
-        /// The currently available balance of the account, as a 64bit integer in minor units of the currency, eg. pennies for GBP, or cents for EUR and USD.
-        /// </summary>
-        [JsonProperty("balance")]
-        public long Value { get; set; }
+    [JsonProperty("balance")]
+    public long Value { get; set; }
 
-        /// <summary>
-        /// The ISO 4217 currency code.
-        /// </summary>
-        [JsonProperty("currency")]
-        public string Currency { get; set; }
+    /// <summary>
+    /// The ISO 4217 currency code.
+    /// </summary>
+    [JsonProperty("currency")]
+    public string Currency { get; set; }
 
-        /// <summary>
-        /// The amount spent from this account today (considered from approx 4am onwards), as a 64bit integer in minor units of the currency.
-        /// </summary>
-        [JsonProperty("spend_today")]
-        public long SpendToday { get; set; }
-    }
+    /// <summary>
+    /// The amount spent from this account today (considered from approx 4am onwards), as a 64bit integer in minor units of the currency.
+    /// </summary>
+    [JsonProperty("spend_today")]
+    public long SpendToday { get; set; }
 }

--- a/Monzo/CounterParty.cs
+++ b/Monzo/CounterParty.cs
@@ -1,31 +1,30 @@
 ﻿using Newtonsoft.Json;
 
-namespace Monzo
+namespace Monzo;
+
+public class CounterParty
 {
-    public class CounterParty
-    {
-        /// <summary>
-        /// The account number of the counterparty.
-        /// </summary>
-        [JsonProperty("account_number")]
-        public string AccountNumber { get; set; }
+    /// <summary>
+    /// The account number of the counterparty.
+    /// </summary>
+    [JsonProperty("account_number")]
+    public string AccountNumber { get; set; }
 
-        /// <summary>
-        /// The name of the payee.
-        /// </summary>
-        [JsonProperty("name")]
-        public string Name { get; set; }
+    /// <summary>
+    /// The name of the payee.
+    /// </summary>
+    [JsonProperty("name")]
+    public string Name { get; set; }
 
-        /// <summary>
-        /// The sort code of the payee.
-        /// </summary>
-        [JsonProperty("sort_code")]
-        public string SortCode { get; set; }
+    /// <summary>
+    /// The sort code of the payee.
+    /// </summary>
+    [JsonProperty("sort_code")]
+    public string SortCode { get; set; }
 
-        /// <summary>
-        /// The user id of the payee, anonymous if not known.
-        /// </summary>
-        [JsonProperty("user_id")]
-        public string UserId { get; set; }
-    }
+    /// <summary>
+    /// The user id of the payee, anonymous if not known.
+    /// </summary>
+    [JsonProperty("user_id")]
+    public string UserId { get; set; }
 }

--- a/Monzo/ErrorResponse.cs
+++ b/Monzo/ErrorResponse.cs
@@ -2,42 +2,41 @@
 using System.Diagnostics;
 using Newtonsoft.Json;
 
-namespace Monzo
+namespace Monzo;
+
+/// <summary>
+/// Monzo API error response message.
+/// </summary>
+[DebuggerDisplay("[{Error}]")]
+public sealed class ErrorResponse
 {
     /// <summary>
-    /// Monzo API error response message.
+    /// Error response code.
     /// </summary>
-    [DebuggerDisplay("[{Error}]")]
-    public sealed class ErrorResponse
-    {
-        /// <summary>
-        /// Error response code.
-        /// </summary>
-        [JsonProperty("code")]
-        public string Code { get; set; }
+    [JsonProperty("code")]
+    public string Code { get; set; }
 
-        /// <summary>
-        /// Error response error.
-        /// </summary>
-        [JsonProperty("error")]
-        public string Error { get; set; }
+    /// <summary>
+    /// Error response error.
+    /// </summary>
+    [JsonProperty("error")]
+    public string Error { get; set; }
 
-        /// <summary>
-        /// Error response error description.
-        /// </summary>
-        [JsonProperty("error_description")]
-        public string ErrorDescription { get; set; }
+    /// <summary>
+    /// Error response error description.
+    /// </summary>
+    [JsonProperty("error_description")]
+    public string ErrorDescription { get; set; }
 
-        /// <summary>
-        /// Error response message.
-        /// </summary>
-        [JsonProperty("message")]
-        public string Message { get; set; }
+    /// <summary>
+    /// Error response message.
+    /// </summary>
+    [JsonProperty("message")]
+    public string Message { get; set; }
 
-        /// <summary>
-        /// Error response parameters.
-        /// </summary>
-        [JsonProperty("params")]
-        public IDictionary<string, string> Params { get; set; }
-    }
+    /// <summary>
+    /// Error response parameters.
+    /// </summary>
+    [JsonProperty("params")]
+    public IDictionary<string, string> Params { get; set; }
 }

--- a/Monzo/Extensions/DateTimeExtensions.cs
+++ b/Monzo/Extensions/DateTimeExtensions.cs
@@ -1,12 +1,11 @@
 ﻿using System;
 
-namespace Monzo.Extensions
+namespace Monzo.Extensions;
+
+internal static class DateTimeExtensions
 {
-    internal static class DateTimeExtensions
+    public static string ToRfc3339String(this DateTime dateTime)
     {
-        public static string ToRfc3339String(this DateTime dateTime)
-        {
-            return dateTime.ToUniversalTime().ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss'Z'");
-        }
+        return dateTime.ToUniversalTime().ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss'Z'");
     }
 }

--- a/Monzo/IMonzoAuthorizationClient.cs
+++ b/Monzo/IMonzoAuthorizationClient.cs
@@ -2,54 +2,53 @@
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Monzo
+namespace Monzo;
+
+/// <summary>
+/// Monzo API authorization client.
+/// </summary>
+public interface IMonzoAuthorizationClient : IDisposable
 {
     /// <summary>
-    /// Monzo API authorization client.
+    /// Your client ID.
     /// </summary>
-    public interface IMonzoAuthorizationClient : IDisposable
-    {
-        /// <summary>
-        /// Your client ID.
-        /// </summary>
-        string ClientId { get; }
+    string ClientId { get; }
 
-        /// <summary>
-        /// Your client secret.
-        /// </summary>
-        string ClientSecret { get; }
+    /// <summary>
+    /// Your client secret.
+    /// </summary>
+    string ClientSecret { get; }
 
-        /// <summary>
-        /// Generates a Monzo OAuth authorization URL based on state and redirect.
-        /// </summary>
-        /// <param name="state">State which will be passed back to you to prevent tampering.</param>
-        /// <param name="redirectUri">The URI we will redirect back to after an authorization by the resource owner.</param>
-        /// <returns> Returns the OAuth authorization URL. </returns>
-        string GetAuthorizeUrl(string state = null, string redirectUri = null);
+    /// <summary>
+    /// Generates a Monzo OAuth authorization URL based on state and redirect.
+    /// </summary>
+    /// <param name="state">State which will be passed back to you to prevent tampering.</param>
+    /// <param name="redirectUri">The URI we will redirect back to after an authorization by the resource owner.</param>
+    /// <returns> Returns the OAuth authorization URL. </returns>
+    string GetAuthorizeUrl(string state = null, string redirectUri = null);
 
-        /// <summary>
-        /// Exchange this authorization code for an AccessToken, allowing requests to be mande on behalf of a user.
-        /// </summary>
-        /// <param name="authorizationCode">The authorization code.</param>
-        /// <param name="redirectUri">The URL the user should be redrected back to.</param>
-        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        /// <returns>Returns the <see cref="AccessToken"/>.</returns>
-        Task<AccessToken> GetAccessTokenAsync(string authorizationCode, string redirectUri, CancellationToken cancellationToken = new CancellationToken());
+    /// <summary>
+    /// Exchange this authorization code for an AccessToken, allowing requests to be mande on behalf of a user.
+    /// </summary>
+    /// <param name="authorizationCode">The authorization code.</param>
+    /// <param name="redirectUri">The URL the user should be redrected back to.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+    /// <returns>Returns the <see cref="AccessToken"/>.</returns>
+    Task<AccessToken> GetAccessTokenAsync(string authorizationCode, string redirectUri, CancellationToken cancellationToken = new CancellationToken());
 
-        /// <summary>
-        /// Acquires an OAuth2.0 access token. An access token is tied to both your application (the client) and an individual Monzo user and is valid for several hours.
-        /// </summary>
-        /// <param name="username">The user’s email address.</param>
-        /// <param name="password">The user’s password.</param>
-        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        Task<AccessToken> AuthenticateAsync(string username, string password, CancellationToken cancellationToken = new CancellationToken());
+    /// <summary>
+    /// Acquires an OAuth2.0 access token. An access token is tied to both your application (the client) and an individual Monzo user and is valid for several hours.
+    /// </summary>
+    /// <param name="username">The user’s email address.</param>
+    /// <param name="password">The user’s password.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+    Task<AccessToken> AuthenticateAsync(string username, string password, CancellationToken cancellationToken = new CancellationToken());
 
-        /// <summary>
-        /// Exchange this authorization code for an AccessToken, allowing requests to be mande on behalf of a user.
-        /// </summary>
-        /// <param name="refreshToken">The refresh token.</param>
-        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        /// <returns>Returns an <see cref="AccessToken"/>.</returns>
-        Task<AccessToken> RefreshAccessTokenAsync(string refreshToken, CancellationToken cancellationToken = new CancellationToken());
-    }
+    /// <summary>
+    /// Exchange this authorization code for an AccessToken, allowing requests to be mande on behalf of a user.
+    /// </summary>
+    /// <param name="refreshToken">The refresh token.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+    /// <returns>Returns an <see cref="AccessToken"/>.</returns>
+    Task<AccessToken> RefreshAccessTokenAsync(string refreshToken, CancellationToken cancellationToken = new CancellationToken());
 }

--- a/Monzo/IMonzoClient.cs
+++ b/Monzo/IMonzoClient.cs
@@ -1,144 +1,142 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Monzo
+namespace Monzo;
+
+/// <summary>
+/// An authenticated Monzo API client.
+/// </summary>
+public interface IMonzoClient : IDisposable
 {
     /// <summary>
-    /// An authenticated Monzo API client.
+    /// Your OAuth 2.0 access token.
     /// </summary>
-    public interface IMonzoClient : IDisposable
-    {
-        /// <summary>
-        /// Your OAuth 2.0 access token.
-        /// </summary>
-        string AccessToken { get; }
+    string AccessToken { get; }
 
-        /// <summary>
-        /// Returns information about the current access token.
-        /// </summary>
-        Task<WhoAmI> WhoAmIAsync();
+    /// <summary>
+    /// Returns information about the current access token.
+    /// </summary>
+    Task<WhoAmI> WhoAmIAsync();
 
-        /// <summary>
-        /// Returns a list of accounts owned by the currently authorised user.
-        /// </summary>
-        Task<IList<Account>> GetAccountsAsync();
+    /// <summary>
+    /// Returns a list of accounts owned by the currently authorised user.
+    /// </summary>
+    Task<IList<Account>> GetAccountsAsync();
 
-        /// <summary>
-        /// Returns balance information for a specific account.
-        /// </summary>
-        /// <param name="accountId">The id of the account.</param>
-        Task<Balance> GetBalanceAsync(string accountId);
+    /// <summary>
+    /// Returns balance information for a specific account.
+    /// </summary>
+    /// <param name="accountId">The id of the account.</param>
+    Task<Balance> GetBalanceAsync(string accountId);
 
-        /// <summary>
-        /// Returns an individual transaction, fetched by its id.
-        /// </summary>
-        /// <param name="transactionId">The transaction ID.</param>
-        /// <param name="expand">Can be merchant.</param>
-        Task<Transaction> GetTransactionAsync(string transactionId, string expand = null);
+    /// <summary>
+    /// Returns an individual transaction, fetched by its id.
+    /// </summary>
+    /// <param name="transactionId">The transaction ID.</param>
+    /// <param name="expand">Can be merchant.</param>
+    Task<Transaction> GetTransactionAsync(string transactionId, string expand = null);
 
-        /// <summary>
-        /// Returns a list of transactions on the user’s account.
-        /// </summary>
-        /// <param name="accountId">The account to retrieve transactions from.</param>
-        /// <param name="expand">Can be merchant.</param>
-        /// <param name="paginationOptions">This endpoint can be paginated.</param>
-        Task<IList<Transaction>> GetTransactionsAsync(string accountId, string expand = null, PaginationOptions paginationOptions = null);
+    /// <summary>
+    /// Returns a list of transactions on the userâ€™s account.
+    /// </summary>
+    /// <param name="accountId">The account to retrieve transactions from.</param>
+    /// <param name="expand">Can be merchant.</param>
+    /// <param name="paginationOptions">This endpoint can be paginated.</param>
+    Task<IList<Transaction>> GetTransactionsAsync(string accountId, string expand = null, PaginationOptions paginationOptions = null);
 
-        /// <summary>
-        /// You may store your own key-value annotations against a transaction in its metadata.
-        /// </summary>
-        /// <param name="transactionId"></param>
-        /// <param name="metadata">Include each key you would like to modify. To delete a key, set its value to an empty string.</param>
-        /// <remarks>Metadata is private to your application.</remarks>
-        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        Task<Transaction> AnnotateTransactionAsync(string transactionId, IDictionary<string, string> metadata, CancellationToken cancellationToken = default(CancellationToken));
+    /// <summary>
+    /// You may store your own key-value annotations against a transaction in its metadata.
+    /// </summary>
+    /// <param name="transactionId"></param>
+    /// <param name="metadata">Include each key you would like to modify. To delete a key, set its value to an empty string.</param>
+    /// <remarks>Metadata is private to your application.</remarks>
+    /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+    Task<Transaction> AnnotateTransactionAsync(string transactionId, IDictionary<string, string> metadata, CancellationToken cancellationToken = default(CancellationToken));
 
-        /// <summary>
-        /// Creates a new feed item on the user’s feed.
-        /// </summary>
-        /// <param name="accountId">The account to create feed item for.</param>
-        /// <param name="type">Type of feed item. Currently only basic is supported.</param>
-        /// <param name="params">A map of parameters which vary based on type</param>
-        /// <param name="url">A URL to open when the feed item is tapped. If no URL is provided, the app will display a fallback view based on the title &amp; body.</param>
-        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        Task CreateFeedItemAsync(string accountId, string type, IDictionary<string, string> @params, string url = null, CancellationToken cancellationToken = default(CancellationToken));
+    /// <summary>
+    /// Creates a new feed item on the userâ€™s feed.
+    /// </summary>
+    /// <param name="accountId">The account to create feed item for.</param>
+    /// <param name="type">Type of feed item. Currently only basic is supported.</param>
+    /// <param name="params">A map of parameters which vary based on type</param>
+    /// <param name="url">A URL to open when the feed item is tapped. If no URL is provided, the app will display a fallback view based on the title &amp; body.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+    Task CreateFeedItemAsync(string accountId, string type, IDictionary<string, string> @params, string url = null, CancellationToken cancellationToken = default(CancellationToken));
 
-        /// <summary>
-        /// Each time a matching event occurs, we will make a POST call to the URL you provide. If the call fails, we will retry up to a maximum of 5 attempts, with exponential backoff.
-        /// </summary>
-        /// <param name="accountId">The account to receive notifications for.</param>
-        /// <param name="url">The URL we will send notifications to.</param>
-        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        Task<Webhook> CreateWebhookAsync(string accountId, string url, CancellationToken cancellationToken = default(CancellationToken));
+    /// <summary>
+    /// Each time a matching event occurs, we will make a POST call to the URL you provide. If the call fails, we will retry up to a maximum of 5 attempts, with exponential backoff.
+    /// </summary>
+    /// <param name="accountId">The account to receive notifications for.</param>
+    /// <param name="url">The URL we will send notifications to.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+    Task<Webhook> CreateWebhookAsync(string accountId, string url, CancellationToken cancellationToken = default(CancellationToken));
 
-        /// <summary>
-        /// List the web hooks registered on an account.
-        /// </summary>
-        /// <param name="accountId">The account to list registered web hooks for.</param>
-        Task<IList<Webhook>> GetWebhooksAsync(string accountId);
+    /// <summary>
+    /// List the web hooks registered on an account.
+    /// </summary>
+    /// <param name="accountId">The account to list registered web hooks for.</param>
+    Task<IList<Webhook>> GetWebhooksAsync(string accountId);
 
-        /// <summary>
-        /// When you delete a web hook, we will no longer send notifications to it.
-        /// </summary>
-        /// <param name="webhookId">The id of the webhook to delete.</param>
-        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        Task DeleteWebhookAsync(string webhookId, CancellationToken cancellationToken = default(CancellationToken));
+    /// <summary>
+    /// When you delete a web hook, we will no longer send notifications to it.
+    /// </summary>
+    /// <param name="webhookId">The id of the webhook to delete.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+    Task DeleteWebhookAsync(string webhookId, CancellationToken cancellationToken = default(CancellationToken));
 
-        /// <summary>
-        /// Uploads an attachment from a file stream.
-        /// </summary>
-        /// <param name="filename">The name of the file to be uploaded</param>
-        /// <param name="fileType">The content type of the file</param>
-        /// <param name="externalId">The id of the transaction to associate the attachment with.</param>
-        /// <param name="stream">The file stream.</param>
-        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        Task<Attachment> UploadAttachmentAsync(string filename, string fileType, string externalId, Stream stream, CancellationToken cancellationToken = default(CancellationToken));
+    /// <summary>
+    /// Uploads an attachment from a file stream.
+    /// </summary>
+    /// <param name="filename">The name of the file to be uploaded</param>
+    /// <param name="fileType">The content type of the file</param>
+    /// <param name="externalId">The id of the transaction to associate the attachment with.</param>
+    /// <param name="stream">The file stream.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+    Task<Attachment> UploadAttachmentAsync(string filename, string fileType, string externalId, Stream stream, CancellationToken cancellationToken = default(CancellationToken));
 
-        /// <summary>
-        /// Once you have obtained a URL for an attachment, either by uploading to the upload_url obtained from the upload endpoint above or by hosting a remote image, this URL can then be registered against a transaction. Once an attachment is registered against a transaction this will be displayed on the detail page of a transaction within the Monzo app.
-        /// </summary>
-        /// <param name="externalId">The id of the transaction to associate the attachment with.</param>
-        /// <param name="fileUrl">The URL of the uploaded attachment.</param>
-        /// <param name="fileType">The content type of the attachment.</param>
-        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        Task<Attachment> CreateAttachmentAsync(string externalId, string fileUrl, string fileType, CancellationToken cancellationToken = default(CancellationToken));
+    /// <summary>
+    /// Once you have obtained a URL for an attachment, either by uploading to the upload_url obtained from the upload endpoint above or by hosting a remote image, this URL can then be registered against a transaction. Once an attachment is registered against a transaction this will be displayed on the detail page of a transaction within the Monzo app.
+    /// </summary>
+    /// <param name="externalId">The id of the transaction to associate the attachment with.</param>
+    /// <param name="fileUrl">The URL of the uploaded attachment.</param>
+    /// <param name="fileType">The content type of the attachment.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+    Task<Attachment> CreateAttachmentAsync(string externalId, string fileUrl, string fileType, CancellationToken cancellationToken = default(CancellationToken));
 
-        /// <summary>
-        /// To remove an attachment, simply deregister this using its id
-        /// </summary>
-        /// <param name="id">The id of the attachment to deregister.</param>
-        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        Task DeleteAttachmentAsync(string id, CancellationToken cancellationToken = default(CancellationToken));
+    /// <summary>
+    /// To remove an attachment, simply deregister this using its id
+    /// </summary>
+    /// <param name="id">The id of the attachment to deregister.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+    Task DeleteAttachmentAsync(string id, CancellationToken cancellationToken = default(CancellationToken));
 
-        /// <summary>
-        /// Returns a list of pots owned by the currently authorised user.
-        /// </summary>
-        Task<IList<Pot>> GetPotsAsync(string currentAccountId);
+    /// <summary>
+    /// Returns a list of pots owned by the currently authorised user.
+    /// </summary>
+    Task<IList<Pot>> GetPotsAsync(string currentAccountId);
 
-        /// <summary>
-        /// Move money from an account owned by the currently authorised user into one of their pots.
-        /// </summary>
-        /// <param name="potId">The id of the pot to deposit into.</param>
-        /// <param name="sourceAccountId">The id of the account to withdraw from.</param>
-        /// <param name="amount">The amount to deposit, as a 64bit integer in minor units of the currency, eg. pennies for GBP, or cents for EUR and USD.</param>
-        /// <param name="dedupeId">A unique string used to de-duplicate deposits. Ensure this remains static between retries to ensure only one deposit is created.</param>
-        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        /// <returns>Updated information about the pot deposited into</returns>
-        Task<Pot> DepositIntoPotAsync(string potId, string sourceAccountId, long amount, string dedupeId, CancellationToken cancellationToken = default(CancellationToken));
+    /// <summary>
+    /// Move money from an account owned by the currently authorised user into one of their pots.
+    /// </summary>
+    /// <param name="potId">The id of the pot to deposit into.</param>
+    /// <param name="sourceAccountId">The id of the account to withdraw from.</param>
+    /// <param name="amount">The amount to deposit, as a 64bit integer in minor units of the currency, eg. pennies for GBP, or cents for EUR and USD.</param>
+    /// <param name="dedupeId">A unique string used to de-duplicate deposits. Ensure this remains static between retries to ensure only one deposit is created.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+    /// <returns>Updated information about the pot deposited into</returns>
+    Task<Pot> DepositIntoPotAsync(string potId, string sourceAccountId, long amount, string dedupeId, CancellationToken cancellationToken = default(CancellationToken));
 
-        /// <summary>
-        /// Move money from a pot owned by the currently authorised user into one of their accounts.
-        /// </summary>
-        /// <param name="potId">The id of the pot to deposit into.</param>
-        /// <param name="destinationAccountId">The id of the account to deposit into.</param>
-        /// <param name="amount">The amount to deposit, as a 64bit integer in minor units of the currency, eg. pennies for GBP, or cents for EUR and USD.</param>
-        /// <param name="dedupeId">A unique string used to de-duplicate deposits. Ensure this remains static between retries to ensure only one withdrawal is created.</param>
-        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        /// <returns>Updated information about the pot withdrawn from</returns>
-        Task<Pot> WithdrawFromPotAsync(string potId, string destinationAccountId, long amount, string dedupeId, CancellationToken cancellationToken = default(CancellationToken));
-    }
+    /// <summary>
+    /// Move money from a pot owned by the currently authorised user into one of their accounts.
+    /// </summary>
+    /// <param name="potId">The id of the pot to deposit into.</param>
+    /// <param name="destinationAccountId">The id of the account to deposit into.</param>
+    /// <param name="amount">The amount to deposit, as a 64bit integer in minor units of the currency, eg. pennies for GBP, or cents for EUR and USD.</param>
+    /// <param name="dedupeId">A unique string used to de-duplicate deposits. Ensure this remains static between retries to ensure only one withdrawal is created.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+    /// <returns>Updated information about the pot withdrawn from</returns>
+    Task<Pot> WithdrawFromPotAsync(string potId, string destinationAccountId, long amount, string dedupeId, CancellationToken cancellationToken = default(CancellationToken));
 }

--- a/Monzo/Merchant.cs
+++ b/Monzo/Merchant.cs
@@ -2,60 +2,59 @@ using System;
 using System.Diagnostics;
 using Newtonsoft.Json;
 
-namespace Monzo
+namespace Monzo;
+
+/// <summary>
+/// The merchant a transaction wasd made at.
+/// </summary>
+[DebuggerDisplay("[{Id,nq} {Name}]")]
+public sealed class Merchant
 {
     /// <summary>
-    /// The merchant a transaction wasd made at.
+    /// The address of the merchant.
     /// </summary>
-    [DebuggerDisplay("[{Id,nq} {Name}]")]
-    public sealed class Merchant
-    {
-        /// <summary>
-        /// The address of the merchant.
-        /// </summary>
-        [JsonProperty("address")]
-        public MerchantAddress Address { get; set; }
+    [JsonProperty("address")]
+    public MerchantAddress Address { get; set; }
 
-        /// <summary>
-        /// The time the merchant was created at.
-        /// </summary>
-        [JsonProperty("created")]
-        public DateTime Created { get; set; }
+    /// <summary>
+    /// The time the merchant was created at.
+    /// </summary>
+    [JsonProperty("created")]
+    public DateTime Created { get; set; }
 
-        /// <summary>
-        /// Used to group individual merchants who are part of a chain.
-        /// </summary>
-        [JsonProperty("group_id")]
-        public string GroupId { get; set; }
+    /// <summary>
+    /// Used to group individual merchants who are part of a chain.
+    /// </summary>
+    [JsonProperty("group_id")]
+    public string GroupId { get; set; }
 
-        /// <summary>
-        /// The merchant's Id.
-        /// </summary>
-        [JsonProperty("id")]
-        public string Id { get; set; }
+    /// <summary>
+    /// The merchant's Id.
+    /// </summary>
+    [JsonProperty("id")]
+    public string Id { get; set; }
 
-        /// <summary>
-        /// The merchant's logo image URL.
-        /// </summary>
-        [JsonProperty("logo")]
-        public string Logo { get; set; }
+    /// <summary>
+    /// The merchant's logo image URL.
+    /// </summary>
+    [JsonProperty("logo")]
+    public string Logo { get; set; }
 
-        /// <summary>
-        /// The emoji displayed for the merchant.
-        /// </summary>
-        [JsonProperty("emoji")]
-        public string Emoji { get; set; }
+    /// <summary>
+    /// The emoji displayed for the merchant.
+    /// </summary>
+    [JsonProperty("emoji")]
+    public string Emoji { get; set; }
 
-        /// <summary>
-        /// The name of the merchant.
-        /// </summary>
-        [JsonProperty("name")]
-        public string Name { get; set; }
+    /// <summary>
+    /// The name of the merchant.
+    /// </summary>
+    [JsonProperty("name")]
+    public string Name { get; set; }
 
-        /// <summary>
-        /// The category of the merchant.
-        /// </summary>
-        [JsonProperty("category")]
-        public string Category { get; set; }
-    }
+    /// <summary>
+    /// The category of the merchant.
+    /// </summary>
+    [JsonProperty("category")]
+    public string Category { get; set; }
 }

--- a/Monzo/MerchantAddress.cs
+++ b/Monzo/MerchantAddress.cs
@@ -1,52 +1,51 @@
 using Newtonsoft.Json;
 
-namespace Monzo
+namespace Monzo;
+
+/// <summary>
+/// The merchant's address.
+/// </summary>
+public sealed class MerchantAddress
 {
     /// <summary>
     /// The merchant's address.
     /// </summary>
-    public sealed class MerchantAddress
-    {
-        /// <summary>
-        /// The merchant's address.
-        /// </summary>
-        [JsonProperty("address")]
-        public string Address { get; set; }
+    [JsonProperty("address")]
+    public string Address { get; set; }
 
-        /// <summary>
-        /// The merchant's city.
-        /// </summary>
-        [JsonProperty("city")]
-        public string City { get; set; }
+    /// <summary>
+    /// The merchant's city.
+    /// </summary>
+    [JsonProperty("city")]
+    public string City { get; set; }
 
-        /// <summary>
-        /// The merchant's country.
-        /// </summary>
-        [JsonProperty("country")]
-        public string Country { get; set; }
+    /// <summary>
+    /// The merchant's country.
+    /// </summary>
+    [JsonProperty("country")]
+    public string Country { get; set; }
 
-        /// <summary>
-        /// The merchant's latitude.
-        /// </summary>
-        [JsonProperty("latitude")]
-        public double Latitude { get; set; }
+    /// <summary>
+    /// The merchant's latitude.
+    /// </summary>
+    [JsonProperty("latitude")]
+    public double Latitude { get; set; }
 
-        /// <summary>
-        /// The merchant's longitude.
-        /// </summary>
-        [JsonProperty("longitude")]
-        public double Longitude { get; set; }
+    /// <summary>
+    /// The merchant's longitude.
+    /// </summary>
+    [JsonProperty("longitude")]
+    public double Longitude { get; set; }
 
-        /// <summary>
-        /// The merchant's postcode.
-        /// </summary>
-        [JsonProperty("postcode")]
-        public string Postcode { get; set; }
+    /// <summary>
+    /// The merchant's postcode.
+    /// </summary>
+    [JsonProperty("postcode")]
+    public string Postcode { get; set; }
 
-        /// <summary>
-        /// The merchant's region.
-        /// </summary>
-        [JsonProperty("region")]
-        public string Region { get; set; }
-    }
+    /// <summary>
+    /// The merchant's region.
+    /// </summary>
+    [JsonProperty("region")]
+    public string Region { get; set; }
 }

--- a/Monzo/Messages/AnnotateTransactionResponse.cs
+++ b/Monzo/Messages/AnnotateTransactionResponse.cs
@@ -1,10 +1,9 @@
 using Newtonsoft.Json;
 
-namespace Monzo.Messages
+namespace Monzo.Messages;
+
+internal sealed class AnnotateTransactionResponse
 {
-    internal sealed class AnnotateTransactionResponse
-    {
-        [JsonProperty("transaction")]
-        public Transaction Transaction { get; set; }
-    }
+    [JsonProperty("transaction")]
+    public Transaction Transaction { get; set; }
 }

--- a/Monzo/Messages/ListAccountsResponse.cs
+++ b/Monzo/Messages/ListAccountsResponse.cs
@@ -1,11 +1,10 @@
 ﻿using System.Collections.Generic;
 using Newtonsoft.Json;
 
-namespace Monzo.Messages
+namespace Monzo.Messages;
+
+internal sealed class ListAccountsResponse
 {
-    internal sealed class ListAccountsResponse
-    {
-        [JsonProperty("accounts")]
-        public IList<Account> Accounts { get; set; }
-    }
+    [JsonProperty("accounts")]
+    public IList<Account> Accounts { get; set; }
 }

--- a/Monzo/Messages/ListPotsResponse.cs
+++ b/Monzo/Messages/ListPotsResponse.cs
@@ -1,11 +1,10 @@
 ﻿using System.Collections.Generic;
 using Newtonsoft.Json;
 
-namespace Monzo.Messages
+namespace Monzo.Messages;
+
+internal sealed class ListPotsResponse
 {
-    internal sealed class ListPotsResponse
-    {
-        [JsonProperty("pots")]
-        public IList<Pot> Pots { get; set; }
-    }
+    [JsonProperty("pots")]
+    public IList<Pot> Pots { get; set; }
 }

--- a/Monzo/Messages/ListTransactionsResponse.cs
+++ b/Monzo/Messages/ListTransactionsResponse.cs
@@ -1,11 +1,10 @@
 using System.Collections.Generic;
 using Newtonsoft.Json;
 
-namespace Monzo.Messages
+namespace Monzo.Messages;
+
+internal sealed class ListTransactionsResponse
 {
-    internal sealed class ListTransactionsResponse
-    {
-        [JsonProperty("transactions")]
-        public IList<Transaction> Transactions { get; set; }
-    }
+    [JsonProperty("transactions")]
+    public IList<Transaction> Transactions { get; set; }
 }

--- a/Monzo/Messages/ListWebhooksResponse.cs
+++ b/Monzo/Messages/ListWebhooksResponse.cs
@@ -1,11 +1,10 @@
 using System.Collections.Generic;
 using Newtonsoft.Json;
 
-namespace Monzo.Messages
+namespace Monzo.Messages;
+
+internal sealed class ListWebhooksResponse
 {
-    internal sealed class ListWebhooksResponse
-    {
-        [JsonProperty("webhooks")]
-        public IList<Webhook> Webhooks { get; set; }
-    }
+    [JsonProperty("webhooks")]
+    public IList<Webhook> Webhooks { get; set; }
 }

--- a/Monzo/Messages/MerchantJsonConverter.cs
+++ b/Monzo/Messages/MerchantJsonConverter.cs
@@ -2,34 +2,33 @@ using System;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
-namespace Monzo.Messages
+namespace Monzo.Messages;
+
+internal sealed class MerchantJsonConverter : JsonConverter
 {
-    internal sealed class MerchantJsonConverter : JsonConverter
+    public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
     {
-        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        throw new NotImplementedException();
+    }
+
+    public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+    {
+        JToken token = JToken.Load(reader);
+        switch (token.Type)
         {
-            throw new NotImplementedException();
+            case JTokenType.Object:
+                return token.ToObject<Merchant>();
+
+            case JTokenType.String:
+                return new Merchant {Id = token.ToString()};
+
+            default:
+                return null;
         }
+    }
 
-        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
-        {
-            JToken token = JToken.Load(reader);
-            switch (token.Type)
-            {
-                case JTokenType.Object:
-                    return token.ToObject<Merchant>();
-
-                case JTokenType.String:
-                    return new Merchant {Id = token.ToString()};
-
-                default:
-                    return null;
-            }
-        }
-
-        public override bool CanConvert(Type objectType)
-        {
-            return objectType == typeof (Merchant);
-        }
+    public override bool CanConvert(Type objectType)
+    {
+        return objectType == typeof (Merchant);
     }
 }

--- a/Monzo/Messages/RegisterAttachmentResponse.cs
+++ b/Monzo/Messages/RegisterAttachmentResponse.cs
@@ -1,10 +1,9 @@
 using Newtonsoft.Json;
 
-namespace Monzo.Messages
+namespace Monzo.Messages;
+
+internal sealed class RegisterAttachmentResponse
 {
-    internal sealed class RegisterAttachmentResponse
-    {
-        [JsonProperty("attachment")]
-        public Attachment Attachment { get; set; }
-    }
+    [JsonProperty("attachment")]
+    public Attachment Attachment { get; set; }
 }

--- a/Monzo/Messages/RegisterWebhookResponse.cs
+++ b/Monzo/Messages/RegisterWebhookResponse.cs
@@ -1,10 +1,9 @@
 using Newtonsoft.Json;
 
-namespace Monzo.Messages
+namespace Monzo.Messages;
+
+internal sealed class RegisterWebhookResponse
 {
-    internal sealed class RegisterWebhookResponse
-    {
-        [JsonProperty("webhook")]
-        public Webhook Webhook { get; set; }
-    }
+    [JsonProperty("webhook")]
+    public Webhook Webhook { get; set; }
 }

--- a/Monzo/Messages/RetrieveTransactionResponse.cs
+++ b/Monzo/Messages/RetrieveTransactionResponse.cs
@@ -1,10 +1,9 @@
 using Newtonsoft.Json;
 
-namespace Monzo.Messages
+namespace Monzo.Messages;
+
+internal sealed class RetrieveTransactionResponse
 {
-    internal sealed class RetrieveTransactionResponse
-    {
-        [JsonProperty("transaction")]
-        public Transaction Transaction { get; set; }
-    }
+    [JsonProperty("transaction")]
+    public Transaction Transaction { get; set; }
 }

--- a/Monzo/Messages/UploadAttachmentResponse.cs
+++ b/Monzo/Messages/UploadAttachmentResponse.cs
@@ -1,19 +1,18 @@
 using Newtonsoft.Json;
 
-namespace Monzo.Messages
-{
-    internal sealed class UploadAttachmentResponse
-    {
-        /// <summary>
-        /// The URL of the file once it has been uploaded
-        /// </summary>
-        [JsonProperty("file_url")]
-        public string FileUrl { get; set; }
+namespace Monzo.Messages;
 
-        /// <summary>
-        /// The URL to POST the file to when uploading
-        /// </summary>
-        [JsonProperty("upload_url")]
-        public string UploadUrl { get; set; }
-    }
+internal sealed class UploadAttachmentResponse
+{
+    /// <summary>
+    /// The URL of the file once it has been uploaded
+    /// </summary>
+    [JsonProperty("file_url")]
+    public string FileUrl { get; set; }
+
+    /// <summary>
+    /// The URL to POST the file to when uploading
+    /// </summary>
+    [JsonProperty("upload_url")]
+    public string UploadUrl { get; set; }
 }

--- a/Monzo/Monzo.csproj
+++ b/Monzo/Monzo.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.1</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <PackageId>Monzo</PackageId>
     <AssemblyTitle>Monzo.NET</AssemblyTitle>
     <Version>0.12.0</Version>
@@ -14,14 +14,15 @@
     <PackageLicenseUrl>https://github.com/JoeEcob/monzo.net/raw/dev/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/JoeEcob/monzo.net</PackageProjectUrl>
     <PackageIconUrl>https://twitter.com/monzo/profile_image?size=original</PackageIconUrl>
+    <LangVersion>default</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <Folder Include="Properties\" />
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="Properties\" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
   </ItemGroup>
 
 </Project>

--- a/Monzo/Monzo.csproj
+++ b/Monzo/Monzo.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
     <PackageId>Monzo</PackageId>
     <AssemblyTitle>Monzo.NET</AssemblyTitle>
     <Version>0.12.0</Version>
@@ -15,6 +14,7 @@
     <PackageProjectUrl>https://github.com/JoeEcob/monzo.net</PackageProjectUrl>
     <PackageIconUrl>https://twitter.com/monzo/profile_image?size=original</PackageIconUrl>
     <LangVersion>default</LangVersion>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Monzo/MonzoAuthorizationClient.cs
+++ b/Monzo/MonzoAuthorizationClient.cs
@@ -7,161 +7,160 @@ using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 
-namespace Monzo
+namespace Monzo;
+
+/// <summary>
+/// Monzo API authorization client.
+/// </summary>
+public sealed class MonzoAuthorizationClient : IMonzoAuthorizationClient
 {
+    private readonly HttpClient _httpClient;
+
     /// <summary>
-    /// Monzo API authorization client.
+    /// Your client ID.
     /// </summary>
-    public sealed class MonzoAuthorizationClient : IMonzoAuthorizationClient
+    public string ClientId { get; }
+
+    /// <summary>
+    /// Your client secret.
+    /// </summary>
+    public string ClientSecret { get; }
+
+    /// <summary>
+    /// Initialises a new <see cref="MonzoAuthorizationClient"/>
+    /// </summary>
+    /// <param name="clientId">Your client ID.</param>
+    /// <param name="clientSecret">Tour client secret.</param>
+    /// <param name="baseUri">URL of the Monzo API to use, defaults to production.</param>
+    public MonzoAuthorizationClient(string clientId, string clientSecret, string baseUri = "https://api.monzo.com") 
+        : this(new HttpClient { BaseAddress = new Uri(baseUri) }, clientId, clientSecret)
     {
-        private readonly HttpClient _httpClient;
+    }
 
-        /// <summary>
-        /// Your client ID.
-        /// </summary>
-        public string ClientId { get; }
+    /// <summary>
+    /// Initialises a new <see cref="MonzoAuthorizationClient"/>
+    /// </summary>
+    /// <param name="httpClient">HttpClient to use.</param>
+    /// <param name="clientId">Your client ID.</param>
+    /// <param name="clientSecret">Tour client secret.</param>
+    internal MonzoAuthorizationClient(HttpClient httpClient, string clientId, string clientSecret)
+    {
+        if (httpClient == null) throw new ArgumentNullException(nameof(httpClient));
+        if (string.IsNullOrWhiteSpace(clientId)) throw new ArgumentException("Parameter is required", nameof(clientId));
+        if (string.IsNullOrWhiteSpace(clientSecret)) throw new ArgumentException("Parameter is required", nameof(clientSecret));
 
-        /// <summary>
-        /// Your client secret.
-        /// </summary>
-        public string ClientSecret { get; }
+        _httpClient = httpClient;
+        ClientId = clientId;
+        ClientSecret = clientSecret;
+    }
 
-        /// <summary>
-        /// Initialises a new <see cref="MonzoAuthorizationClient"/>
-        /// </summary>
-        /// <param name="clientId">Your client ID.</param>
-        /// <param name="clientSecret">Tour client secret.</param>
-        /// <param name="baseUri">URL of the Monzo API to use, defaults to production.</param>
-        public MonzoAuthorizationClient(string clientId, string clientSecret, string baseUri = "https://api.monzo.com") 
-            : this(new HttpClient { BaseAddress = new Uri(baseUri) }, clientId, clientSecret)
+    /// <summary>
+    /// Generates a Monzo OAuth authorization URL based on state and redirect.
+    /// </summary>
+    /// <param name="state">State which will be passed back to you to prevent tampering.</param>
+    /// <param name="redirectUri">The URI we will redirect back to after an authorization by the resource owner.</param>
+    /// <returns> Returns the OAuth authorization URL. </returns>
+    public string GetAuthorizeUrl(string state = null, string redirectUri = null)
+    {
+        var sb = new StringBuilder("https://auth.monzo.com/?response_type=code&client_id=");
+        sb.Append(ClientId);
+
+        if (!string.IsNullOrWhiteSpace(state))
         {
+            sb.Append("&state=");
+            sb.Append(state);
         }
 
-        /// <summary>
-        /// Initialises a new <see cref="MonzoAuthorizationClient"/>
-        /// </summary>
-        /// <param name="httpClient">HttpClient to use.</param>
-        /// <param name="clientId">Your client ID.</param>
-        /// <param name="clientSecret">Tour client secret.</param>
-        internal MonzoAuthorizationClient(HttpClient httpClient, string clientId, string clientSecret)
+        if (!string.IsNullOrWhiteSpace(redirectUri))
         {
-            if (httpClient == null) throw new ArgumentNullException(nameof(httpClient));
-            if (string.IsNullOrWhiteSpace(clientId)) throw new ArgumentException("Parameter is required", nameof(clientId));
-            if (string.IsNullOrWhiteSpace(clientSecret)) throw new ArgumentException("Parameter is required", nameof(clientSecret));
-
-            _httpClient = httpClient;
-            ClientId = clientId;
-            ClientSecret = clientSecret;
+            sb.Append("&redirect_uri=");
+            sb.Append(WebUtility.UrlEncode(redirectUri));
         }
 
-        /// <summary>
-        /// Generates a Monzo OAuth authorization URL based on state and redirect.
-        /// </summary>
-        /// <param name="state">State which will be passed back to you to prevent tampering.</param>
-        /// <param name="redirectUri">The URI we will redirect back to after an authorization by the resource owner.</param>
-        /// <returns> Returns the OAuth authorization URL. </returns>
-        public string GetAuthorizeUrl(string state = null, string redirectUri = null)
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Exchange this authorization code for an AccessToken, allowing requests to be mande on behalf of a user.
+    /// </summary>
+    /// <param name="authorizationCode">The authorization code.</param>
+    /// <param name="redirectUri">The URL the user should be redrected back to.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+    /// <returns>Returns the <see cref="AccessToken"/>.</returns>
+    public async Task<AccessToken> GetAccessTokenAsync(string authorizationCode, string redirectUri, CancellationToken cancellationToken = new CancellationToken())
+    {
+        var formValues = new Dictionary<string, string>
         {
-            var sb = new StringBuilder("https://auth.monzo.com/?response_type=code&client_id=");
-            sb.Append(ClientId);
+            { "client_id", ClientId },
+            { "client_secret", ClientSecret },
+            { "grant_type", "authorization_code" },
+            { "code", authorizationCode },
+            { "redirect_uri", redirectUri }
+        };
 
-            if (!string.IsNullOrWhiteSpace(state))
-            {
-                sb.Append("&state=");
-                sb.Append(state);
-            }
+        return await AuthorizeAsync(formValues, cancellationToken);
+    }
 
-            if (!string.IsNullOrWhiteSpace(redirectUri))
-            {
-                sb.Append("&redirect_uri=");
-                sb.Append(WebUtility.UrlEncode(redirectUri));
-            }
+    /// <summary>
+    /// Acquires an OAuth2.0 access token. An access token is tied to both your application (the client) and an individual Monzo user and is valid for several hours.
+    /// </summary>
+    /// <param name="username">The user’s email address.</param>
+    /// <param name="password">The user’s password.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+    public async Task<AccessToken> AuthenticateAsync(string username, string password, CancellationToken cancellationToken = new CancellationToken())
+    {
+        if (username == null) throw new ArgumentNullException(nameof(username));
+        if (password == null) throw new ArgumentNullException(nameof(password));
 
-            return sb.ToString();
+        var formValues = new Dictionary<string, string>
+        {
+            {"grant_type", "password"},
+            {"client_id", ClientId},
+            {"client_secret", ClientSecret},
+            {"username", username},
+            {"password", password}
+        };
+
+        return await AuthorizeAsync(formValues, cancellationToken);
+    }
+
+    /// <summary>
+    /// Exchange this authorization code for an AccessToken, allowing requests to be mande on behalf of a user.
+    /// </summary>
+    /// <param name="refreshToken">The refresh token.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+    /// <returns>Returns an <see cref="AccessToken"/>.</returns>
+    public async Task<AccessToken> RefreshAccessTokenAsync(string refreshToken, CancellationToken cancellationToken = new CancellationToken())
+    {
+        var formValues = new Dictionary<string, string>
+        {
+            { "client_id", ClientId },
+            { "client_secret", ClientSecret },
+            { "grant_type", "refresh_token" },
+            { "refresh_token", refreshToken }
+        };
+
+        return await AuthorizeAsync(formValues, cancellationToken);
+    }
+
+    private async Task<AccessToken> AuthorizeAsync(Dictionary<string, string> formValues, CancellationToken cancellationToken = new CancellationToken())
+    {
+        HttpResponseMessage response = await _httpClient.PostAsync("oauth2/token", new FormUrlEncodedContent(formValues), cancellationToken).ConfigureAwait(false);
+        string body = await response.Content.ReadAsStringAsync();
+
+        if (!response.IsSuccessStatusCode)
+        {
+            throw MonzoException.CreateFromApiResponse(response, body);
         }
 
-        /// <summary>
-        /// Exchange this authorization code for an AccessToken, allowing requests to be mande on behalf of a user.
-        /// </summary>
-        /// <param name="authorizationCode">The authorization code.</param>
-        /// <param name="redirectUri">The URL the user should be redrected back to.</param>
-        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        /// <returns>Returns the <see cref="AccessToken"/>.</returns>
-        public async Task<AccessToken> GetAccessTokenAsync(string authorizationCode, string redirectUri, CancellationToken cancellationToken = new CancellationToken())
-        {
-            var formValues = new Dictionary<string, string>
-            {
-                { "client_id", ClientId },
-                { "client_secret", ClientSecret },
-                { "grant_type", "authorization_code" },
-                { "code", authorizationCode },
-                { "redirect_uri", redirectUri }
-            };
+        return JsonConvert.DeserializeObject<AccessToken>(body);
+    }
 
-            return await AuthorizeAsync(formValues, cancellationToken);
-        }
-
-        /// <summary>
-        /// Acquires an OAuth2.0 access token. An access token is tied to both your application (the client) and an individual Monzo user and is valid for several hours.
-        /// </summary>
-        /// <param name="username">The user’s email address.</param>
-        /// <param name="password">The user’s password.</param>
-        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        public async Task<AccessToken> AuthenticateAsync(string username, string password, CancellationToken cancellationToken = new CancellationToken())
-        {
-            if (username == null) throw new ArgumentNullException(nameof(username));
-            if (password == null) throw new ArgumentNullException(nameof(password));
-
-            var formValues = new Dictionary<string, string>
-            {
-                {"grant_type", "password"},
-                {"client_id", ClientId},
-                {"client_secret", ClientSecret},
-                {"username", username},
-                {"password", password}
-            };
-
-            return await AuthorizeAsync(formValues, cancellationToken);
-        }
-
-        /// <summary>
-        /// Exchange this authorization code for an AccessToken, allowing requests to be mande on behalf of a user.
-        /// </summary>
-        /// <param name="refreshToken">The refresh token.</param>
-        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        /// <returns>Returns an <see cref="AccessToken"/>.</returns>
-        public async Task<AccessToken> RefreshAccessTokenAsync(string refreshToken, CancellationToken cancellationToken = new CancellationToken())
-        {
-            var formValues = new Dictionary<string, string>
-            {
-                { "client_id", ClientId },
-                { "client_secret", ClientSecret },
-                { "grant_type", "refresh_token" },
-                { "refresh_token", refreshToken }
-            };
-
-            return await AuthorizeAsync(formValues, cancellationToken);
-        }
-
-        private async Task<AccessToken> AuthorizeAsync(Dictionary<string, string> formValues, CancellationToken cancellationToken = new CancellationToken())
-        {
-            HttpResponseMessage response = await _httpClient.PostAsync("oauth2/token", new FormUrlEncodedContent(formValues), cancellationToken).ConfigureAwait(false);
-            string body = await response.Content.ReadAsStringAsync();
-
-            if (!response.IsSuccessStatusCode)
-            {
-                throw MonzoException.CreateFromApiResponse(response, body);
-            }
-
-            return JsonConvert.DeserializeObject<AccessToken>(body);
-        }
-
-        /// <summary>
-        /// Disposes the underlying HttpClient.
-        /// </summary>
-        public void Dispose()
-        {
-            _httpClient.Dispose();
-        }
+    /// <summary>
+    /// Disposes the underlying HttpClient.
+    /// </summary>
+    public void Dispose()
+    {
+        _httpClient.Dispose();
     }
 }

--- a/Monzo/MonzoException.cs
+++ b/Monzo/MonzoException.cs
@@ -3,46 +3,45 @@ using System.Net;
 using System.Net.Http;
 using Newtonsoft.Json;
 
-namespace Monzo
+namespace Monzo;
+
+/// <summary>
+/// Represents an error response from the Monzo API.
+/// </summary>
+public sealed class MonzoException : Exception
 {
     /// <summary>
-    /// Represents an error response from the Monzo API.
+    /// Initializes a new instance of the <see cref="MonzoClient"/> class.
     /// </summary>
-    public sealed class MonzoException : Exception
+    /// <param name="statusCode">HTTP status code.</param>
+    /// <param name="message">The message that describes the error.</param>
+    /// <param name="response">The error response returned from the API.</param>
+    public MonzoException(HttpStatusCode statusCode, string message, ErrorResponse response = null) :base(message)
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MonzoClient"/> class.
-        /// </summary>
-        /// <param name="statusCode">HTTP status code.</param>
-        /// <param name="message">The message that describes the error.</param>
-        /// <param name="response">The error response returned from the API.</param>
-        public MonzoException(HttpStatusCode statusCode, string message, ErrorResponse response = null) :base(message)
+        StatusCode = statusCode;
+        Response = response;
+    }
+
+    /// <summary>
+    /// The HTTP status code.
+    /// </summary>
+    public HttpStatusCode StatusCode { get; }
+
+    /// <summary>
+    /// The error response returned from the API.
+    /// </summary>
+    public ErrorResponse Response { get; }
+
+    internal static MonzoException CreateFromApiResponse(HttpResponseMessage response, string body)
+    {
+        try
         {
-            StatusCode = statusCode;
-            Response = response;
+            var errorResponse = JsonConvert.DeserializeObject<ErrorResponse>(body);
+            return new MonzoException(response.StatusCode, body, errorResponse);
         }
-
-        /// <summary>
-        /// The HTTP status code.
-        /// </summary>
-        public HttpStatusCode StatusCode { get; }
-
-        /// <summary>
-        /// The error response returned from the API.
-        /// </summary>
-        public ErrorResponse Response { get; }
-
-        internal static MonzoException CreateFromApiResponse(HttpResponseMessage response, string body)
+        catch
         {
-            try
-            {
-                var errorResponse = JsonConvert.DeserializeObject<ErrorResponse>(body);
-                return new MonzoException(response.StatusCode, body, errorResponse);
-            }
-            catch
-            {
-                return new MonzoException(response.StatusCode, body);
-            }
+            return new MonzoException(response.StatusCode, body);
         }
     }
 }

--- a/Monzo/PaginationOptions.cs
+++ b/Monzo/PaginationOptions.cs
@@ -1,42 +1,41 @@
 ﻿using System;
 using Monzo.Extensions;
 
-namespace Monzo
+namespace Monzo;
+
+/// <summary>
+/// Endpoints which enumerate objects support time-based and cursor-based pagination.
+/// </summary>
+public sealed class PaginationOptions
 {
     /// <summary>
-    /// Endpoints which enumerate objects support time-based and cursor-based pagination.
+    /// Limits the number of results per-page.
     /// </summary>
-    public sealed class PaginationOptions
+    public int? Limit { get; set; }
+
+    /// <summary>
+    /// An RFC 3339-encoded timestamp.
+    /// </summary>
+    public DateTime? SinceTime { get; set; }
+
+    /// <summary>
+    /// Or an object id.
+    /// </summary>
+    public string SinceId { get; set; }
+
+    /// <summary>
+    /// An RFC 3339 encoded-timestamp
+    /// </summary>
+    public DateTime? BeforeTime { get; set; }
+
+    /// <summary>
+    /// Format the pagination options as a query string.
+    /// </summary>
+    public override string ToString()
     {
-        /// <summary>
-        /// Limits the number of results per-page.
-        /// </summary>
-        public int? Limit { get; set; }
+        string since = SinceTime?.ToRfc3339String() ?? SinceId;
+        string before = BeforeTime?.ToRfc3339String();
 
-        /// <summary>
-        /// An RFC 3339-encoded timestamp.
-        /// </summary>
-        public DateTime? SinceTime { get; set; }
-
-        /// <summary>
-        /// Or an object id.
-        /// </summary>
-        public string SinceId { get; set; }
-
-        /// <summary>
-        /// An RFC 3339 encoded-timestamp
-        /// </summary>
-        public DateTime? BeforeTime { get; set; }
-
-        /// <summary>
-        /// Format the pagination options as a query string.
-        /// </summary>
-        public override string ToString()
-        {
-            string since = SinceTime?.ToRfc3339String() ?? SinceId;
-            string before = BeforeTime?.ToRfc3339String();
-
-            return $"&limit={Limit}&since={since}&before={before}";
-        }
+        return $"&limit={Limit}&since={since}&before={before}";
     }
 }

--- a/Monzo/Pot.cs
+++ b/Monzo/Pot.cs
@@ -2,80 +2,79 @@
 using System.Collections.Generic;
 using Newtonsoft.Json;
 
-namespace Monzo
+namespace Monzo;
+
+public class Pot
 {
-    public class Pot
-    {
-        /// <summary>
-        /// The id of the pot.
-        /// </summary>
-        [JsonProperty("id")]
-        public string Id { get; set; }
+    /// <summary>
+    /// The id of the pot.
+    /// </summary>
+    [JsonProperty("id")]
+    public string Id { get; set; }
 
-        /// <summary>
-        /// The name of the pot.
-        /// </summary>
-        [JsonProperty("name")]
-        public string Name { get; set; }
+    /// <summary>
+    /// The name of the pot.
+    /// </summary>
+    [JsonProperty("name")]
+    public string Name { get; set; }
 
-        /// <summary>
-        /// The style of the pot.
-        /// </summary>
-        [JsonProperty("style")]
-        public string Style { get; set; }
+    /// <summary>
+    /// The style of the pot.
+    /// </summary>
+    [JsonProperty("style")]
+    public string Style { get; set; }
 
-        /// <summary>
-        /// Current balance for the pot.
-        /// </summary>
-        [JsonProperty("balance")]
-        public long Balance { get; set; }
+    /// <summary>
+    /// Current balance for the pot.
+    /// </summary>
+    [JsonProperty("balance")]
+    public long Balance { get; set; }
 
-        /// <summary>
-        /// Currency type for the pot.
-        /// </summary>
-        [JsonProperty("currency")]
-        public string Currency { get; set; }
+    /// <summary>
+    /// Currency type for the pot.
+    /// </summary>
+    [JsonProperty("currency")]
+    public string Currency { get; set; }
 
-        /// <summary>
-        /// A list of permissions for the pot. Usually contains a user_id and a permission_type.
-        /// </summary>
-        [JsonProperty("assigned_permissions")]
-        public List<Dictionary<string, string>> AssignedPermissions { get; set; }
+    /// <summary>
+    /// A list of permissions for the pot. Usually contains a user_id and a permission_type.
+    /// </summary>
+    [JsonProperty("assigned_permissions")]
+    public List<Dictionary<string, string>> AssignedPermissions { get; set; }
 
-        /// <summary>
-        /// The current account id being used when making a pot deposit / withdrawal.
-        /// </summary>
-        [JsonProperty("current_account_id")]
-        public string CurrentAccountId { get; set; }
+    /// <summary>
+    /// The current account id being used when making a pot deposit / withdrawal.
+    /// </summary>
+    [JsonProperty("current_account_id")]
+    public string CurrentAccountId { get; set; }
 
-        /// <summary>
-        /// Date and time the pot was created.
-        /// </summary>
-        [JsonProperty("created")]
-        public DateTime Created { get; set; }
+    /// <summary>
+    /// Date and time the pot was created.
+    /// </summary>
+    [JsonProperty("created")]
+    public DateTime Created { get; set; }
 
-        /// <summary>
-        /// Date and time the pot was last updated (includes withdrawals / deposits).
-        /// </summary>
-        [JsonProperty("updated")]
-        public DateTime Updated { get; set; }
+    /// <summary>
+    /// Date and time the pot was last updated (includes withdrawals / deposits).
+    /// </summary>
+    [JsonProperty("updated")]
+    public DateTime Updated { get; set; }
 
-        /// <summary>
-        /// Flag for if this pot should be used to round the change.
-        /// </summary>
-        [JsonProperty("round_up")]
-        public bool RoundUp { get; set; }
+    /// <summary>
+    /// Flag for if this pot should be used to round the change.
+    /// </summary>
+    [JsonProperty("round_up")]
+    public bool RoundUp { get; set; }
 
-        /// <summary>
-        /// Flag for if the pot is currently locked.
-        /// </summary>
-        [JsonProperty("locked")]
-        public bool Locked { get; set; }
+    /// <summary>
+    /// Flag for if the pot is currently locked.
+    /// </summary>
+    [JsonProperty("locked")]
+    public bool Locked { get; set; }
 
-        /// <summary>
-        /// Flag for if the pot is deleted.
-        /// </summary>
-        [JsonProperty("deleted")]
-        public bool Deleted { get; set; }
-    }
+    /// <summary>
+    /// Flag for if the pot is deleted.
+    /// </summary>
+    [JsonProperty("deleted")]
+    public bool Deleted { get; set; }
 }

--- a/Monzo/Transaction.cs
+++ b/Monzo/Transaction.cs
@@ -4,103 +4,102 @@ using System.Diagnostics;
 using Monzo.Messages;
 using Newtonsoft.Json;
 
-namespace Monzo
+namespace Monzo;
+
+/// <summary>
+/// Transactions are movements of funds into or out of an account. Negative transactions represent debits (ie. spending money) and positive transactions represent credits (ie. receiving money).
+/// </summary>
+[DebuggerDisplay("[{Id,nq} {Amount} {Currency,nq} {Description}]")]
+public sealed class Transaction
 {
     /// <summary>
-    /// Transactions are movements of funds into or out of an account. Negative transactions represent debits (ie. spending money) and positive transactions represent credits (ie. receiving money).
+    /// The currently available balance of the account, as a 64bit integer in minor units of the currency, eg. pennies for GBP, or cents for EUR and USD.
     /// </summary>
-    [DebuggerDisplay("[{Id,nq} {Amount} {Currency,nq} {Description}]")]
-    public sealed class Transaction
-    {
-        /// <summary>
-        /// The currently available balance of the account, as a 64bit integer in minor units of the currency, eg. pennies for GBP, or cents for EUR and USD.
-        /// </summary>
-        [JsonProperty("account_balance")]
-        public long AccountBalance { get; set; }
+    [JsonProperty("account_balance")]
+    public long AccountBalance { get; set; }
 
-        /// <summary>
-        /// The amount of the transaction in minor units of currency. For example pennies in the case of GBP. A negative amount indicates a debit (most card transactions will have a negative amount)
-        /// </summary>
-        [JsonProperty("amount")]
-        public long Amount { get; set; }
+    /// <summary>
+    /// The amount of the transaction in minor units of currency. For example pennies in the case of GBP. A negative amount indicates a debit (most card transactions will have a negative amount)
+    /// </summary>
+    [JsonProperty("amount")]
+    public long Amount { get; set; }
 
-        /// <summary>
-        /// This is only present on declined transactions! Valid values are INSUFFICIENT_FUNDS, CARD_INACTIVE, CARD_BLOCKED or OTHER.
-        /// </summary>
-        [JsonProperty("decline_reason")]
-        public string DeclineReason { get; set; }
+    /// <summary>
+    /// This is only present on declined transactions! Valid values are INSUFFICIENT_FUNDS, CARD_INACTIVE, CARD_BLOCKED or OTHER.
+    /// </summary>
+    [JsonProperty("decline_reason")]
+    public string DeclineReason { get; set; }
 
-        /// <summary>
-        /// The category can be set for each transaction by the user. Over time we learn which merchant goes in which category and auto-assign the category of a transaction. If the user hasnít set a category, weíll return the default category of the merchant on this transactions. Top-ups have category ìmonzoî. Valid values are general, eating_out, expenses, transport, cash, bills, entertainment, shopping, holidays, groceries
-        /// </summary>
-        [JsonProperty("category")]
-        public string Category { get; set; }
+    /// <summary>
+    /// The category can be set for each transaction by the user. Over time we learn which merchant goes in which category and auto-assign the category of a transaction. If the user hasn‚Äôt set a category, we‚Äôll return the default category of the merchant on this transactions. Top-ups have category ‚Äúmonzo‚Äù. Valid values are general, eating_out, expenses, transport, cash, bills, entertainment, shopping, holidays, groceries
+    /// </summary>
+    [JsonProperty("category")]
+    public string Category { get; set; }
 
-        /// <summary>
-        /// Details of the payee if the transaction was a bank transfer. Null otherwise.
-        /// </summary>
-        [JsonProperty("counterparty")]
-        public CounterParty CounterParty { get; set; }
+    /// <summary>
+    /// Details of the payee if the transaction was a bank transfer. Null otherwise.
+    /// </summary>
+    [JsonProperty("counterparty")]
+    public CounterParty CounterParty { get; set; }
 
-        /// <summary>
-        /// Time the transaction was created.
-        /// </summary>
-        [JsonProperty("created")]
-        public DateTime Created { get; set; }
+    /// <summary>
+    /// Time the transaction was created.
+    /// </summary>
+    [JsonProperty("created")]
+    public DateTime Created { get; set; }
 
-        /// <summary>
-        /// The ISO 4217 currency code.
-        /// </summary>
-        [JsonProperty("currency")]
-        public string Currency { get; set; }
+    /// <summary>
+    /// The ISO 4217 currency code.
+    /// </summary>
+    [JsonProperty("currency")]
+    public string Currency { get; set; }
 
-        /// <summary>
-        /// Transaction description.
-        /// </summary>
-        [JsonProperty("description")]
-        public string Description { get; set; }
+    /// <summary>
+    /// Transaction description.
+    /// </summary>
+    [JsonProperty("description")]
+    public string Description { get; set; }
 
-        /// <summary>
-        /// The transaction's Id.
-        /// </summary>
-        [JsonProperty("id")]
-        public string Id { get; set; }
+    /// <summary>
+    /// The transaction's Id.
+    /// </summary>
+    [JsonProperty("id")]
+    public string Id { get; set; }
 
-        /// <summary>
-        /// Flag for if the transaction should be included in your spending summary.
-        /// </summary>
-        [JsonProperty("include_in_spending")]
-        public bool IncludeInSpending { get; set; }
+    /// <summary>
+    /// Flag for if the transaction should be included in your spending summary.
+    /// </summary>
+    [JsonProperty("include_in_spending")]
+    public bool IncludeInSpending { get; set; }
 
-        /// <summary>
-        /// Top-ups to an account are represented as transactions with a positive amount and is_load = true. Other transactions such as refunds, reversals or chargebacks may have a positive amount but is_load = false
-        /// </summary>
-        [JsonProperty("is_load")]
-        public bool IsLoad { get; set; }
+    /// <summary>
+    /// Top-ups to an account are represented as transactions with a positive amount and is_load = true. Other transactions such as refunds, reversals or chargebacks may have a positive amount but is_load = false
+    /// </summary>
+    [JsonProperty("is_load")]
+    public bool IsLoad { get; set; }
 
-        /// <summary>
-        /// This contains the merchant_id of the merchant that this transaction was made at. If you pass ?expand[]=merchant in your request URL, it will contain lots of information about the merchant.
-        /// </summary>
-        [JsonProperty("merchant")]
-        [JsonConverter(typeof(MerchantJsonConverter))]
-        public Merchant Merchant { get; set; }
+    /// <summary>
+    /// This contains the merchant_id of the merchant that this transaction was made at. If you pass ?expand[]=merchant in your request URL, it will contain lots of information about the merchant.
+    /// </summary>
+    [JsonProperty("merchant")]
+    [JsonConverter(typeof(MerchantJsonConverter))]
+    public Merchant Merchant { get; set; }
 
-        /// <summary>
-        /// You may store your own key-value annotations against a transaction in its metadata. Metadata is private to your application.
-        /// </summary>
-        [JsonProperty("metadata")]
-        public IDictionary<string, string> Metadata { get; set; }
+    /// <summary>
+    /// You may store your own key-value annotations against a transaction in its metadata. Metadata is private to your application.
+    /// </summary>
+    [JsonProperty("metadata")]
+    public IDictionary<string, string> Metadata { get; set; }
 
-        /// <summary>
-        /// Notes entered by the user against the transaction.
-        /// </summary>
-        [JsonProperty("notes")]
-        public string Notes { get; set; }
+    /// <summary>
+    /// Notes entered by the user against the transaction.
+    /// </summary>
+    [JsonProperty("notes")]
+    public string Notes { get; set; }
 
-        /// <summary>
-        /// You probably donít need to worry about this. Card transactions only settle 24-48 hours (sometimes even more!) after the purchase; until then they are just ìauthorisedî and settled = false on them.
-        /// </summary>
-        [JsonProperty("settled")]
-        public string Settled { get; set; }
-    }
+    /// <summary>
+    /// You probably don‚Äôt need to worry about this. Card transactions only settle 24-48 hours (sometimes even more!) after the purchase; until then they are just ‚Äúauthorised‚Äù and settled = false on them.
+    /// </summary>
+    [JsonProperty("settled")]
+    public string Settled { get; set; }
 }

--- a/Monzo/User.cs
+++ b/Monzo/User.cs
@@ -1,29 +1,28 @@
 using System.Diagnostics;
 using Newtonsoft.Json;
 
-namespace Monzo {
-    
+namespace Monzo;
+
+/// <summary>
+/// User represents the details of an account.
+/// </summary>
+[DebuggerDisplay("[{Id,nq} {PreferredName}]")]
+public sealed class User {
     /// <summary>
-    /// User represents the details of an account.
+    /// The id of the user.
     /// </summary>
-    [DebuggerDisplay("[{Id,nq} {PreferredName}]")]
-    public sealed class User {
-        /// <summary>
-        /// The id of the user.
-        /// </summary>
-        [JsonProperty("user_id")]
-        public string Id { get; set; }
+    [JsonProperty("user_id")]
+    public string Id { get; set; }
         
-        /// <summary>
-        /// The preferred Name of the user.
-        /// </summary>
-        [JsonProperty("preferred_name")]
-        public string PreferredName { get; set; }
+    /// <summary>
+    /// The preferred Name of the user.
+    /// </summary>
+    [JsonProperty("preferred_name")]
+    public string PreferredName { get; set; }
         
-        /// <summary>
-        /// The preferred First Name of the user.
-        /// </summary>
-        [JsonProperty("preferred_first_name")]
-        public string PreferredFirstName { get; set; }
-    }
+    /// <summary>
+    /// The preferred First Name of the user.
+    /// </summary>
+    [JsonProperty("preferred_first_name")]
+    public string PreferredFirstName { get; set; }
 }

--- a/Monzo/Webhook.cs
+++ b/Monzo/Webhook.cs
@@ -1,30 +1,29 @@
 using System.Diagnostics;
 using Newtonsoft.Json;
 
-namespace Monzo
+namespace Monzo;
+
+/// <summary>
+/// Web hooks allow your application to receive real-time, push notification of events in an account.
+/// </summary>
+[DebuggerDisplay("[{Id,nq} {Url}]")]
+public sealed class Webhook
 {
     /// <summary>
-    /// Web hooks allow your application to receive real-time, push notification of events in an account.
+    /// The account to list registered web hooks for.
     /// </summary>
-    [DebuggerDisplay("[{Id,nq} {Url}]")]
-    public sealed class Webhook
-    {
-        /// <summary>
-        /// The account to list registered web hooks for.
-        /// </summary>
-        [JsonProperty("account_id")]
-        public string AccountId { get; set; }
+    [JsonProperty("account_id")]
+    public string AccountId { get; set; }
 
-        /// <summary>
-        /// The webhook's Id.
-        /// </summary>
-        [JsonProperty("id")]
-        public string Id { get; set; }
+    /// <summary>
+    /// The webhook's Id.
+    /// </summary>
+    [JsonProperty("id")]
+    public string Id { get; set; }
 
-        /// <summary>
-        /// The URL we will send notifications to.
-        /// </summary>
-        [JsonProperty("url")]
-        public string Url { get; set; }
-    }
+    /// <summary>
+    /// The URL we will send notifications to.
+    /// </summary>
+    [JsonProperty("url")]
+    public string Url { get; set; }
 }

--- a/Monzo/WhoAmI.cs
+++ b/Monzo/WhoAmI.cs
@@ -1,31 +1,27 @@
-﻿using System;
-using System.Diagnostics;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
-namespace Monzo
+namespace Monzo;
+
+/// <summary>
+/// Returns information about the current access token.
+/// </summary>
+public sealed class WhoAmI
 {
     /// <summary>
-    /// Returns information about the current access token.
+    /// Boolean for if the user is authenticated.
     /// </summary>
-    [DebuggerDisplay("[{Id,nq} {Description}]")]
-    public sealed class WhoAmI
-    {
-        /// <summary>
-        /// Boolean for if the user is authenticated.
-        /// </summary>
-        [JsonProperty("authenticated")]
-        public bool Authenticated { get; set; }
+    [JsonProperty("authenticated")]
+    public bool Authenticated { get; set; }
 
-        /// <summary>
-        /// The id of the client.
-        /// </summary>
-        [JsonProperty("client_id")]
-        public string ClientId { get; set; }
+    /// <summary>
+    /// The id of the client.
+    /// </summary>
+    [JsonProperty("client_id")]
+    public string ClientId { get; set; }
 
-        /// <summary>
-        /// The id of the user.
-        /// </summary>
-        [JsonProperty("user_id")]
-        public string UserId { get; set; }
-    }
+    /// <summary>
+    /// The id of the user.
+    /// </summary>
+    [JsonProperty("user_id")]
+    public string UserId { get; set; }
 }

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Monzo.NET is a .NET client library for the [Monzo bank API](https://monzo.com/do
 Install-Package Monzo
 ```
 
-Supported target frameworks: .Net Core, .NET 4.5, ASP.NET Core 5.0, Windows 8, Windows Phone 8.1
+Supported target frameworks: [.NET Standard 2.0](https://learn.microsoft.com/en-us/dotnet/standard/net-standard?tabs=net-standard-2-0), [.NET Standard 2.1](https://learn.microsoft.com/en-us/dotnet/standard/net-standard?tabs=net-standard-2-1)
 
 ### Supported Features
 


### PR DESCRIPTION
Upgrading to .NET Standard 2.0/2.1

Upgrading tests to .NET 7.0

Upgrading all NuGet packages to latest versions.

Fixed warnings, broken `<summary>` tag comment, refactored to use file-scoped namespaces.

Test suite fully passing.

![image](https://user-images.githubusercontent.com/1159378/219483311-6c242124-e74e-4bc8-b498-a8835235bbf7.png)
